### PR TITLE
[codex] Add CST simulation workflow skill

### DIFF
--- a/Skill/CST/README.md
+++ b/Skill/CST/README.md
@@ -1,0 +1,7 @@
+# CST Skills
+
+This folder contains CST Studio Suite workflow skills designed to work with the repository CST MCP under `MCP/CST`.
+
+| Skill | Purpose |
+| --- | --- |
+| [cst-simulation-workflow](cst-simulation-workflow) | Workflow and decision layer for CST electromagnetic simulations through the CST MCP, including parameter resolution, templates, execution rules, result validation, sweeps, and reports. |

--- a/Skill/CST/README.zh-CN.md
+++ b/Skill/CST/README.zh-CN.md
@@ -1,0 +1,7 @@
+# CST Skills
+
+这个目录存放配合仓库 `MCP/CST` 使用的 CST Studio Suite 工作流 skills。
+
+| Skill | 用途 |
+| --- | --- |
+| [cst-simulation-workflow](cst-simulation-workflow) | 通过 CST MCP 编排电磁仿真流程，覆盖参数补全、模板选择、执行规则、结果校验、扫参和报告输出。 |

--- a/Skill/CST/cst-simulation-workflow/SKILL.md
+++ b/Skill/CST/cst-simulation-workflow/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cst-simulation-workflow
+description: Use this skill when driving CST Studio Suite through the CST MCP for electromagnetic simulation workflows: creating or opening CST projects, resolving missing inputs, selecting templates, setting up geometry/materials/ports/boundaries/mesh/solvers/monitors, running or planning simulations, extracting S-parameters/far-field/near-field/eigenmode results, validating outputs, parameter sweeps, optimization handoff, and report generation.
+---
+
+# CST Simulation Workflow
+
+Use this skill as the workflow and decision layer. Use the CST MCP as the execution layer.
+
+Prefer the repository CST MCP native tools for live session control. Use the vendored `cst_runtime_*` or `cst_toolbox_*` wrappers for larger command catalogs, workspace pipelines, result export, parameter sweeps, and optimization helpers.
+
+## Operating Modes
+
+First classify the request:
+
+| Mode | Use when | Action |
+| --- | --- | --- |
+| Plan only | User asks for a scheme, script outline, or workflow | Do not run CST; produce the setup plan and assumptions |
+| New project | User wants a new CST case | Select a template, resolve inputs, create a run project |
+| Existing project | User provides a `.cst` path or asks to modify an open project | Inspect first, then work on a copy unless explicitly told otherwise |
+| Parameter sweep | User asks for ranges, cases, or comparison | Use sweep preview before running cases |
+| Optimization | User asks to improve S11, gain, bandwidth, coupling, etc. | Hand off to runtime optimization workflow after confirming objective and bounds |
+
+## Standard Workflow
+
+1. Detect CST MCP availability and CST Design Environment status.
+2. Determine whether to create a new project, open a copy of an existing `.cst`, or only generate a plan.
+3. Identify the simulation class and select a template when appropriate.
+4. Resolve missing inputs using the parameter policy.
+5. Present a compact defaults card before expensive solves unless the user already said to use defaults or run directly.
+6. Build or modify geometry, materials, coordinate system, ports/excitations, boundaries, mesh, solver, and monitors.
+7. Save the working project before running a solver.
+8. Run the solver only when the user requested execution or accepted the defaults.
+9. Extract result tree items and export requested data.
+10. Validate results against the objective and evidence requirements.
+11. Generate a concise report with assumptions, files, commands/tools used, result paths, and validation status.
+12. Close/cleanup the CST project/session and report any nonblocking residual locks or access-denied cleanup messages.
+
+## Reference Files
+
+Read only the reference file needed for the current task:
+
+- `references/workflow.md` for the end-to-end workflow and mode-specific execution details.
+- `references/parameter-policy.md` for required questions, defaults, derived values, and existing-project inspection.
+- `references/mcp-tool-map.md` for this repository's CST MCP tool names and when to prefer native vs runtime tools.
+- `references/templates.md` for V1 simulation templates and default values.
+- `references/result-validation.md` for S-parameter, far-field, near-field, eigenmode, sweep, and report validation.
+- `references/cst-red-lines.md` for correctness and safety rules that must not be violated.
+
+## Input Policy
+
+Ask at most one compact clarification when critical information is missing. If the user says "directly run", "use defaults", "先默认", or equivalent, use defaults and record them in the report.
+
+Critical inputs that usually require confirmation:
+
+- simulation case type
+- target frequency or frequency band
+- new project vs existing project
+- primary result objective
+- whether to actually run the solver
+
+Defaultable inputs include units, background, common metals, antenna boundaries, solver choice, monitor frequencies, mesh level, and standard result exports. See `references/parameter-policy.md`.
+
+## Execution Rules
+
+- Do not overwrite a user's source `.cst` project. Copy it to a run directory unless the user explicitly requests in-place edits.
+- Inspect existing projects before changing them.
+- Prefer CST Macro Recorder-style VBA history blocks for modeling operations when no higher-level MCP tool exists.
+- Save before solving.
+- Treat solver success as unverified until result files, result tree entries, or exported data confirm it.
+- For long or costly solves, state the assumptions and expected outputs before running.
+
+## Result Rules
+
+- Do not treat complex S-parameter values as dB. Convert with `20*log10(abs(S11))`.
+- Do not report `Abs(E)` as gain. Use `Realized Gain`, `Gain`, or `Directivity` for far-field gain claims.
+- Keep model-building/session operations separate from result-reading operations when the tool surface exposes separate modes.
+- Include exact evidence paths for project files, exports, reports, and logs.
+
+## V1 Scope
+
+Focus V1 on:
+
+- a single new standard antenna case, especially a 2.4 GHz Wi-Fi/IoT microstrip patch antenna;
+- opening an existing `.cst`, inspecting it, changing parameters, and rerunning on a copy;
+- S11, VSWR, far-field gain/directivity, radiation pattern, eigenmode frequency, and concise Markdown report outputs;
+- parameter sweep preview/run through the CST MCP sweep tools.
+
+Use 77 GHz 1x4 radar patch array as a demonstration template after the basic workflow is stable.

--- a/Skill/CST/cst-simulation-workflow/agents/openai.yaml
+++ b/Skill/CST/cst-simulation-workflow/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: CST Simulation Workflow
+short_description: Drive CST Studio Suite simulations through the CST MCP with defaults, validation, and reports.
+default_prompt: Use the CST simulation workflow skill to plan or run a CST electromagnetic simulation through the CST MCP. Resolve missing inputs, state defaults, use a copied working project, validate results, and report evidence files.

--- a/Skill/CST/cst-simulation-workflow/metadata.json
+++ b/Skill/CST/cst-simulation-workflow/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "cst-simulation-workflow",
+  "dir_name": "cst-simulation-workflow",
+  "category": "electromagnetic-simulation",
+  "status": "local",
+  "source": "local",
+  "source_url": "",
+  "license": "NOASSERTION",
+  "distribution": "internal",
+  "description": "Workflow and decision-layer skill for driving CST Studio Suite through the repository CST MCP."
+}

--- a/Skill/CST/cst-simulation-workflow/references/cst-red-lines.md
+++ b/Skill/CST/cst-simulation-workflow/references/cst-red-lines.md
@@ -1,0 +1,54 @@
+# CST Red Lines
+
+These rules protect correctness, source projects, and CST session stability.
+
+## Project Safety
+
+- Do not overwrite the user's source `.cst` file. Work on a copied project unless explicitly told otherwise.
+- Preserve companion project folders when copying `.cst` files; CST results and metadata may live beside the file.
+- Inspect existing/open projects before writing.
+- If multiple projects are open and the target is ambiguous, stop and ask for the target project.
+- Save before long solves.
+- Report `.lok` locks or cleanup failures; do not hide them.
+
+## Session and Process Safety
+
+- Treat "MCP server alive" and "CST project usable" as separate states.
+- Do not assume the Design Environment has a project loaded just because CST is running.
+- Keep modeler operations and result-reading operations separate when the API/tooling separates them.
+- Close or cleanup the working project at the end of an execution task, unless the user explicitly wants CST left open.
+- Record access-denied cleanup residuals as nonblocking only when result evidence is already saved.
+
+## Numerical Correctness
+
+- S-parameters may be complex. Convert to dB with `20*log10(abs(S))`.
+- VSWR uses reflection coefficient magnitude, not dB directly.
+- `Abs(E)` is electric-field magnitude, not gain.
+- Far-field gain claims require `Realized Gain`, `Gain`, or `Directivity`.
+- State frequency units explicitly.
+- Do not claim convergence, pass/fail, or optimality without evidence.
+
+## Solver Setup
+
+- Do not set frequency range blindly for every solver. Eigenmode workflows may not need `Solver.FrequencyRange`.
+- Use solver choice appropriate to task:
+  - Time Domain for many broadband antenna S-parameter sweeps.
+  - Frequency Domain for narrowband/high-Q accuracy or when requested.
+  - HF Eigenmode for cavity/mode frequency tasks.
+- Add monitors before solving when monitor outputs are required.
+- Rebuild/save after geometry or parameter changes before solving.
+
+## Reporting
+
+- Do not fabricate solver status, mesh counts, convergence, S11, gain, or mode frequencies.
+- Include exact result paths and result tree items.
+- Mark incomplete result extraction as `needs_validation` or `partial`, not success.
+- Record defaults and assumptions that influenced geometry, solver, or result interpretation.
+
+## Automation Scope
+
+- Prefer existing MCP/runtime tools over new ad hoc scripts.
+- Use small VBA/history blocks with clear titles.
+- Avoid destructive cleanup of unrelated CST processes or unrelated project folders.
+- Do not make broad parameter sweeps without previewing case count.
+- Do not continue optimization after target is reached unless user asks for more exploration.

--- a/Skill/CST/cst-simulation-workflow/references/mcp-tool-map.md
+++ b/Skill/CST/cst-simulation-workflow/references/mcp-tool-map.md
@@ -1,0 +1,90 @@
+# CST MCP Tool Map
+
+Use this file to map workflow steps to this repository's CST MCP tools.
+
+## Native CST MCP Tools
+
+Prefer native tools for live CST Design Environment control.
+
+| Workflow need | Preferred tool |
+| --- | --- |
+| detect CST install, Python paths, running DEs | `cst_detect_tool` |
+| connect or launch CST | `cst_connect_tool` |
+| inspect current project/session | `cst_project_info_tool` |
+| create project | `cst_new_project_tool` |
+| open project | `cst_open_project_tool` |
+| save project | `cst_save_project_tool` |
+| add VBA/history commands | `cst_add_to_history_tool` |
+| run configured 3D solver | `cst_run_solver_tool` |
+| list result tree | `cst_list_results_tool` |
+| read 1D result item | `cst_read_1d_result_tool` |
+| export Touchstone | use the MCP export tool if available, otherwise runtime export helpers |
+| advanced custom control | `cst_run_python_tool` only when simpler tools cannot express the operation |
+
+Use small named `cst_add_to_history_tool` calls. Suggested titles:
+
+- `set units and background`
+- `define materials`
+- `create substrate`
+- `create patch`
+- `create feed`
+- `define ports`
+- `set boundaries`
+- `set mesh`
+- `set solver`
+- `set monitors`
+
+## Runtime / Toolbox Wrapper Tools
+
+Use runtime wrappers for broader command catalogs, workflows, result exports, and optimization helpers:
+
+| Workflow need | Tool |
+| --- | --- |
+| detect runtime availability | `cst_runtime_detect_tool` or `cst_toolbox_detect_tool` |
+| list runtime commands | `cst_runtime_list_tools_tool` or `cst_toolbox_list_tools_tool` |
+| inspect command schema | `cst_runtime_describe_tool` or `cst_toolbox_describe_tool` |
+| create args JSON template | `cst_runtime_args_template_tool` or `cst_toolbox_args_template_tool` |
+| invoke runtime command | `cst_runtime_invoke_tool` or `cst_toolbox_invoke_tool` |
+| list pipelines | `cst_runtime_list_pipelines_tool` or `cst_toolbox_list_pipelines_tool` |
+| usage guide | `cst_runtime_usage_guide_tool` or `cst_toolbox_usage_guide_tool` |
+
+When using `cst_runtime_invoke_tool`, pass the runtime command name and JSON args. Example:
+
+```json
+{
+  "tool_name": "list-result-items",
+  "args": {
+    "project_path": "E:\\Code\\CAE-Agent-Hub\\cst_runs\\case.cst"
+  }
+}
+```
+
+## Parameter Sweep Tools
+
+Use native sweep tools before hand-rolling loops:
+
+| Workflow need | Tool |
+| --- | --- |
+| preview generated parameter cases | `cst_sweep_preview_tool` |
+| run copied per-case projects | `cst_sweep_run_tool` |
+
+Always preview when case count is unknown. Report generated case count, mode, output directory, and whether solves are enabled.
+
+## Typed Wrapper Tools
+
+Use only when developing or refreshing helper code around the vendored toolbox:
+
+| Workflow need | Tool |
+| --- | --- |
+| inspect schema catalog | `cst_toolbox_schema_catalog_tool` |
+| generate typed wrappers | `cst_toolbox_generate_typed_wrappers_tool` |
+
+Do not use typed wrapper generation as part of a normal simulation workflow.
+
+## Fallback Rules
+
+- If a native MCP tool exists for a live action, use it before `cst_run_python_tool`.
+- If no native tool exists, prefer CST Macro Recorder-style VBA through `cst_add_to_history_tool`.
+- Use `cst_run_python_tool` for inspection or control that cannot be expressed by history commands or existing tools.
+- Use runtime wrappers when the task needs repeatable workspace pipelines, result export helpers, optimization, or a large predefined modeling command.
+- Do not invent unverified tool names. Inspect available tools when uncertain.

--- a/Skill/CST/cst-simulation-workflow/references/parameter-policy.md
+++ b/Skill/CST/cst-simulation-workflow/references/parameter-policy.md
@@ -1,0 +1,89 @@
+# Parameter Policy
+
+Use this file when the user omits inputs or asks for defaults.
+
+## Ask Once for Critical Inputs
+
+Ask a compact question only when a missing value can change the simulation meaning.
+
+Critical inputs:
+
+| Input | Why it matters |
+| --- | --- |
+| case type | Patch antenna, array, NFC coil, filter, cavity, and waveguide require different setup |
+| target frequency or band | Drives dimensions, solver range, mesh, and monitors |
+| project source | Determines new-model vs inspect-and-edit workflow |
+| execution intent | CST solves may be slow or license-bound |
+| primary objective | S11, gain, directivity, field strength, mode frequency, coupling, or efficiency imply different outputs |
+
+If several are missing, present a defaults card rather than asking a sequence of questions.
+
+## Defaultable Inputs
+
+Use these defaults when the user says to proceed with defaults:
+
+| Input | Default |
+| --- | --- |
+| units | `mm`, `GHz`, `ns` |
+| background | Vacuum or air |
+| metal | Copper using CST material library/default conductivity |
+| antenna boundary | Open / add space |
+| antenna solver | Time Domain for broadband antenna cases; Frequency Domain when narrowband high-Q accuracy is requested |
+| eigenmode solver | HF Eigenmode |
+| frequency range | `0.7*f0` to `1.3*f0`; for 77 GHz radar use 76-81 GHz |
+| mesh | Normal/adaptive mesh; refine near ports, feed gaps, edges, thin conductors |
+| monitors | S-parameters plus far-field at `f0`; add near-field/current only when useful |
+| outputs | S11, VSWR if available, realized gain/gain/directivity, radiation pattern, result tree, Markdown report |
+| run directory | `cst_runs/<short_task>_<YYYYMMDD>` |
+
+State defaulted values in the report.
+
+## Derived Inputs
+
+For template-based new models, derive initial geometry from frequency and materials:
+
+- Free-space wavelength: `lambda0_mm = 299.792458 / f_GHz`.
+- Patch antenna initial dimensions: use common microstrip patch equations from `templates.md`; treat the result as a starting point, not an optimized design.
+- Substrate outline: patch size plus margin, usually 3-6 substrate heights or a practical factor around 1.5-2.5 times patch dimensions.
+- Feed location: template default first, then optimize if S11 is poor.
+- Far-field monitor frequency: center frequency unless user gives multiple frequencies.
+- Mesh refinement: ports, feed line/gap, patch edges, coil traces, thin dielectrics.
+
+## Existing Project Inputs
+
+When a `.cst` project exists, inspect before asking for values. Prefer reading:
+
+- project path and active/open project identity
+- parameters and values
+- geometry/entity names
+- materials
+- ports/excitations
+- boundaries
+- solver type and frequency range
+- monitors
+- result tree
+- recent messages/logs
+
+Ask the user only for ambiguous choices, such as which parameter to sweep or which result item is the objective.
+
+## Defaults Card Template
+
+Use this shape before expensive solves:
+
+```text
+I will run this CST setup unless you change it:
+
+Case:
+Project:
+Frequency:
+Material/substrate:
+Solver:
+Boundary:
+Ports/excitation:
+Monitors:
+Outputs:
+Run mode:
+Working directory:
+```
+
+If the user already said "directly run" or "use defaults", continue and include this card in the final report instead of pausing.

--- a/Skill/CST/cst-simulation-workflow/references/result-validation.md
+++ b/Skill/CST/cst-simulation-workflow/references/result-validation.md
@@ -1,0 +1,120 @@
+# Result Validation
+
+Use this file before claiming a CST simulation succeeded.
+
+## Evidence Requirements
+
+A run is validated only when at least one concrete evidence source exists:
+
+- saved working `.cst` project path
+- CST result tree entries from `cst_list_results_tool`
+- exported Touchstone, JSON, CSV, TXT, image, or report file
+- readable 1D result from `cst_read_1d_result_tool`
+- solver log or model log showing completion
+
+If the solver command returns success but no result evidence is available, report `needs_validation`.
+
+## S-Parameters
+
+For S11/S-parameters:
+
+- Confirm the result item or Touchstone export exists.
+- If data is complex, compute dB as `20*log10(abs(S11))`.
+- Do not label raw complex magnitude as dB.
+- Report the frequency unit and interpolation method if evaluating at a target frequency.
+- For pass/fail, state the threshold, for example `S11 <= -10 dB at 2.4 GHz`.
+
+Suggested summary:
+
+```text
+S11 validation:
+- target:
+- best frequency:
+- S11 at target:
+- minimum S11 in band:
+- evidence file:
+- status: pass/fail/needs_validation
+```
+
+## VSWR
+
+If VSWR is not directly exported, derive it from reflection coefficient magnitude:
+
+```text
+VSWR = (1 + |Gamma|) / (1 - |Gamma|)
+```
+
+Do not compute VSWR from a dB value without converting back to magnitude.
+
+## Far Field
+
+For gain or radiation pattern claims:
+
+- Use `Realized Gain`, `Gain`, or `Directivity`.
+- Do not use `Abs(E)` as gain or dBi evidence.
+- State frequency, port/excitation, quantity, unit, and coordinate convention.
+- Record whether the plot/data is 3D, theta cut, phi cut, or polar/cartesian.
+
+Suggested summary:
+
+```text
+Far-field validation:
+- quantity:
+- frequency:
+- peak value:
+- main direction:
+- evidence file/result item:
+- status:
+```
+
+## Near Field and Current
+
+For E/H fields, SAR, current, or coupling:
+
+- Confirm the monitor exists before solving or that the result tree contains the item afterward.
+- State field quantity, frequency/time, plane/cut/volume, and unit.
+- Do not infer far-field gain from near-field magnitude.
+
+## Eigenmode
+
+For eigenmode runs:
+
+- Confirm mode frequency result entries exist.
+- Report requested modes and solved modes.
+- Include mode frequencies with units.
+- Note whether boundaries were PEC/electric wall, magnetic wall, open, or symmetry.
+
+## Parameter Sweep
+
+For sweeps:
+
+- Include previewed case count and actual completed/failed case counts.
+- Include sweep mode: `single`, `zip`, or `cartesian`.
+- Include parameter table and objective metric.
+- Identify the best case only if the objective was computed from validated results.
+
+## Report Status Values
+
+Use these statuses consistently:
+
+| Status | Meaning |
+| --- | --- |
+| `validated` | Solver and requested result evidence were found and parsed |
+| `needs_validation` | Project or solver ran, but requested result evidence is missing/incomplete |
+| `blocked` | CST/MCP/license/input/project issue prevented meaningful execution |
+| `plan_only` | User requested planning or script generation without execution |
+| `partial` | Some outputs validated but others failed or were not generated |
+
+## Minimum Final Report
+
+Every executed CST task should include:
+
+- working project path
+- source project path when applicable
+- run directory
+- assumptions/defaults
+- MCP tools used
+- solver and result setup
+- evidence files/result tree entries
+- validation status
+- issues, warnings, and recommended next action

--- a/Skill/CST/cst-simulation-workflow/references/templates.md
+++ b/Skill/CST/cst-simulation-workflow/references/templates.md
@@ -1,0 +1,97 @@
+# CST V1 Templates
+
+Use templates as starting points, not as final validated designs. Simulate and validate before making performance claims.
+
+## Template Selection
+
+| Template | Use when | Stability |
+| --- | --- | --- |
+| 2.4 GHz Wi-Fi/IoT microstrip patch | Need a stable first CST MCP demo or simple antenna workflow | V1 primary |
+| 77 GHz 1x4 radar patch array | Need a modern ADAS/mmWave showcase | V1 demo after patch is stable |
+| Existing `.cst` parameter rerun | User provides a project or wants to modify current model | V1 primary |
+| Rectangular PEC cavity eigenmode | Need a fast verification/eigenmode smoke test | V1 validation case |
+| NFC/Qi coil | Near-field coupling demo | Later |
+
+## 2.4 GHz Wi-Fi/IoT Microstrip Patch
+
+Default card:
+
+| Field | Default |
+| --- | --- |
+| center frequency | 2.4 GHz |
+| sweep range | 1.8-3.0 GHz |
+| substrate | FR-4 if user does not care; Rogers material if loss accuracy matters |
+| substrate thickness | 1.6 mm for FR-4 |
+| metal | Copper |
+| feed | Microstrip feed or discrete/lumped feed, depending on available MCP support |
+| boundary | Open / add space |
+| solver | Time Domain |
+| monitors | S11 over sweep, far-field at 2.4 GHz |
+| outputs | S11, VSWR if available, realized gain/gain/directivity, radiation pattern |
+
+Initial dimension guidance:
+
+- Use effective dielectric constant and patch resonance equations to estimate patch width and length.
+- Use substrate and ground plane dimensions with margin around the patch.
+- Treat feed inset/location as a tunable parameter.
+- If first S11 is poor, suggest a short sweep over patch length and feed position.
+
+## 77 GHz 1x4 Radar Patch Array
+
+Default card:
+
+| Field | Default |
+| --- | --- |
+| frequency band | 76-81 GHz |
+| center frequency | 77 GHz |
+| array | 1x4 linear patch array |
+| substrate | Rogers RO3003 or similar low-loss mmWave substrate |
+| substrate thickness | 0.127 mm if not specified |
+| metal | Copper |
+| element spacing | about 0.5 free-space wavelength, adjusted for layout |
+| feed | corporate feed or individual ports depending on task |
+| boundary | Open / add space |
+| solver | Frequency Domain or Time Domain based on requested outputs and model detail |
+| monitors | S-parameters, far-field at 77 GHz, optional 76/79/81 GHz monitors |
+| outputs | S11, mutual coupling if multiport, realized gain/directivity, main beam direction |
+
+Use this template after the basic single-patch workflow is stable. mmWave arrays are more sensitive to meshing, material loss, feed implementation, and port definitions.
+
+## Rectangular PEC Cavity Eigenmode
+
+Use for a quick end-to-end CST smoke test or eigenmode workflow:
+
+| Field | Default |
+| --- | --- |
+| cavity size | 100 x 50 x 30 mm |
+| material | vacuum/air inside |
+| boundaries | electric wall on all six sides |
+| solver | HF Eigenmode |
+| modes | 3 |
+| outputs | mode frequencies and result tree evidence |
+
+Do not call `Solver.FrequencyRange` for this eigenmode smoke test unless the specific CST setup requires it; doing so can open an interactive dialog when the range is unset.
+
+## Existing Project Parameter Rerun
+
+Default behavior:
+
+1. Copy source `.cst` and companion project folder into the run directory.
+2. Inspect parameters, monitors, solver, ports, and result tree.
+3. Apply only requested parameter changes.
+4. Save and run copied project.
+5. Export comparable results and report before/after values.
+
+If the user does not identify which parameter to change, list candidate geometry/design parameters and ask once.
+
+## Template Report Requirements
+
+Every template run must report:
+
+- template name and version-like date
+- all assumed default values
+- generated/working project path
+- solver type and frequency range or modes
+- ports/excitations
+- monitors
+- outputs and validation status

--- a/Skill/CST/cst-simulation-workflow/references/workflow.md
+++ b/Skill/CST/cst-simulation-workflow/references/workflow.md
@@ -1,0 +1,79 @@
+# CST Workflow
+
+Use this file for task routing and execution order.
+
+## Universal Preflight
+
+1. Confirm the user wants one of: plan only, new project, existing project edit, sweep, or optimization.
+2. Check the CST MCP with `cst_detect_tool`.
+3. Connect with `cst_connect_tool`; set `launch_if_needed=true` only when the user wants execution or live inspection.
+4. Choose a run directory under `cst_runs/<short_task>_<YYYYMMDD>` unless the user specified a path.
+5. Record whether the task is destructive, expensive, or only a plan.
+
+Do not run CST for plan-only tasks. Return the workflow, assumptions, expected outputs, and the MCP tools that would be used.
+
+## New Project Flow
+
+1. Select a template from `templates.md` or derive a case-specific setup.
+2. Resolve required inputs with `parameter-policy.md`.
+3. Show the defaults card if the solve may be expensive.
+4. Create the project with `cst_new_project_tool`.
+5. Add history blocks with `cst_add_to_history_tool` in small named chunks:
+   - units and background
+   - materials
+   - geometry
+   - ports/excitations
+   - boundaries and symmetry
+   - mesh/adaptation
+   - solver
+   - monitors
+6. Save with `cst_save_project_tool`.
+7. Run with `cst_run_solver_tool` only after save.
+8. List results with `cst_list_results_tool`.
+9. Read selected 1D results with `cst_read_1d_result_tool`, export Touchstone when S-parameters are requested.
+10. Generate the report.
+
+## Existing Project Flow
+
+1. Locate the source `.cst` file or active project.
+2. Inspect with `cst_project_info_tool` and, when needed, `cst_list_results_tool`.
+3. Copy source `.cst` and companion result folder to a run directory before editing.
+4. Open the working copy with `cst_open_project_tool`.
+5. Read available parameters, entities, ports, monitors, solver settings, and result tree if the MCP/runtime tools expose them.
+6. Change only requested parameters or settings.
+7. Save, solve, export, validate, and report.
+
+Never rebuild an existing project from scratch unless the user asks for a rebuild.
+
+## Parameter Sweep Flow
+
+1. Require a source `.cst` project or a generated baseline working project.
+2. Parse parameter specs such as `w=1:3:0.5`, arrays, or CSV-like lists.
+3. Preview cases with `cst_sweep_preview_tool`.
+4. Show case count before running if count is large or solves are enabled.
+5. Run with `cst_sweep_run_tool`.
+6. Summarize CSV outputs, result exports, failed cases, and best case by the chosen objective.
+
+Use `single` mode for quick one-factor sweeps, `zip` when values are paired, and `cartesian` only when the case count is acceptable.
+
+## Optimization Flow
+
+1. Confirm objective type, target, parameter bounds, maximum rounds, and stopping rule.
+2. If using the vendored runtime, inspect available pipelines with `cst_runtime_list_pipelines_tool` or `cst_toolbox_list_pipelines_tool`.
+3. Prefer runtime optimization helpers for multi-round loops. Do not hand-write a large independent optimizer unless the user explicitly asks for custom code.
+4. Every round must include: prepare parameters, run/refresh simulation, export/read results, compute objective, decide stop/continue.
+5. Stop early when the target is met or the configured no-improvement rule fires.
+
+## Default Report Shape
+
+Produce a Markdown report unless the user asked for HTML:
+
+- task summary
+- source project and working project paths
+- assumptions/defaults
+- tool sequence used
+- parameter table
+- solver and monitor setup
+- result file paths
+- validation status
+- issues and next recommended changes

--- a/Skill/README.md
+++ b/Skill/README.md
@@ -1,6 +1,6 @@
 # Finite Element Simulation Skills
 
-This directory keeps finite element simulation skills grouped under `abaqus/`.
+This directory keeps reusable CAE simulation skills grouped by solver or domain.
 
 The current layout is:
 
@@ -14,7 +14,9 @@ The current layout is:
 | `abaqus/postprocessing` | ODB/result post-processing skills. |
 | `abaqus/optimization` | Topology, shape, and general optimization skills. |
 | `abaqus/reference` | General FEA and FEniCS reference skills that are useful beside Abaqus workflows. |
+| `CST` | CST Studio Suite electromagnetic simulation workflow skills for use with the CST MCP. |
 
 See [abaqus/README.md](abaqus/README.md) for the full skill index, upstream attribution, and client setup examples.
+See [CST/README.md](CST/README.md) for CST workflow skills.
 
 Chinese version: [README.zh-CN.md](README.zh-CN.md).

--- a/Skill/README.zh-CN.md
+++ b/Skill/README.zh-CN.md
@@ -1,6 +1,6 @@
 # 有限元仿真 Skills
 
-这个目录下的有限元仿真 skills 已统一归到 `abaqus/` 文件夹中。
+这个目录下的可复用 CAE 仿真 skills 按求解器或领域分组。
 
 当前结构：
 
@@ -14,7 +14,9 @@
 | `abaqus/postprocessing` | ODB/结果后处理 skills。 |
 | `abaqus/optimization` | 拓扑优化、形状优化和通用优化 skills。 |
 | `abaqus/reference` | 可配合 Abaqus 使用的通用 FEA 和 FEniCS 参考 skills。 |
+| `CST` | 配合 CST MCP 使用的 CST Studio Suite 电磁仿真流程 skills。 |
 
 完整索引、上游来源和客户端使用方法见 [abaqus/README.zh-CN.md](abaqus/README.zh-CN.md)。
+CST workflow skills 见 [CST/README.zh-CN.md](CST/README.zh-CN.md)。
 
 English version: [README.md](README.md).


### PR DESCRIPTION
## What changed

- Added the `cst-simulation-workflow` orchestration skill for CST Studio Suite and the repository CST MCP.
- Documented parameter resolution, workflow stages, MCP tool mapping, reusable templates, result validation, and CST execution red lines.
- Added Chinese and English CST skill indexes and linked them from the top-level Skill indexes.

## Why

The skill turns repeatable CST simulation steps into a stable workflow while keeping project-specific parameters explicit, defaultable, or user-confirmed.

## Validation

- Verified Skill frontmatter and metadata name.
- Verified all required reference files exist.
- Checked for TODO/TBD/placeholder content.
- Ran `git diff --cached --check` before commit.
