### PR TITLE
Add HyperMesh evidence-first meshing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This repository separates responsibilities:
 | [ovito-evidence-postprocessing](Skill/ovito/ovito-evidence-postprocessing) | Active | Evidence-first OVITO atomistic postprocessing workflow. | OVITO, visualization, atomistic |
 | [ansys-mechanical-evidence-structural](Skill/Ansys/ansys-mechanical-evidence-structural) | Active | Mechanical evidence and acceptance gates, complementary to the Workbench workflow skill. | Mechanical, ACT, PyMechanical, MAPDL |
 | [aedt-evidence-electromagnetics](Skill/Ansys/aedt-evidence-electromagnetics) | Active | Generic AEDT evidence workflow with Maxwell checks. | AEDT, Maxwell, HFSS, PyAEDT |
+| [hypermesh-evidence-meshing](Skill/hypermesh/hypermesh-evidence-meshing) | Active | Feature-aware HyperMesh partitioning, shell/solid meshing, and evidence-gated quality remediation through the HyperWorks MCP. | HyperMesh, meshing, fillet, chamfer, tetra quality |
 | [calculix-fem](Skill/calculix/calculix-fem) | Active | Workflow for driving the CalculiX MCP: inspect a `.inp` deck, edit design variables in place, run ccx, read `.dat` results, export `result_mesh.json`. | CalculiX, FEM, ccx, .inp, linear static |
 | [calculix-sizing-optimization](Skill/calculix/calculix-sizing-optimization) | Active | Two-stage sizing optimization on a CalculiX shell/beam deck (LHS sweep + coordinate descent) to minimize mass s.t. stress/displacement bounds. | CalculiX, sizing optimization, mass reduction, LHS, coordinate descent |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,6 +87,7 @@ AI client
 | [ovito-evidence-postprocessing](Skill/ovito/ovito-evidence-postprocessing) | Active | 证据优先的 OVITO 原子尺度后处理工作流。 | OVITO, visualization, atomistic |
 | [ansys-mechanical-evidence-structural](Skill/Ansys/ansys-mechanical-evidence-structural) | Active | 与 Workbench 主工作流互补的 Mechanical 证据和验收门槛。 | Mechanical, ACT, PyMechanical, MAPDL |
 | [aedt-evidence-electromagnetics](Skill/Ansys/aedt-evidence-electromagnetics) | Active | 含 Maxwell 检查的泛用 AEDT 证据工作流。 | AEDT, Maxwell, HFSS, PyAEDT |
+| [hypermesh-evidence-meshing](Skill/hypermesh/hypermesh-evidence-meshing) | Active | 通过 HyperWorks MCP 进行特征感知的 HyperMesh 分区、壳/实体网格与证据门控质量修复。 | HyperMesh, 网格, 圆角, 倒角, 四面体质量 |
 | [calculix-fem](Skill/calculix/calculix-fem) | Active | 驱动 CalculiX MCP 的工作流：检视 `.inp`、原位修改设计变量、运行 ccx、读取 `.dat` 结果、导出 `result_mesh.json`。 | CalculiX, FEM, ccx, .inp, 线性静力 |
 | [calculix-sizing-optimization](Skill/calculix/calculix-sizing-optimization) | Active | 在 CalculiX 壳/梁 deck 上跑两阶段尺寸优化（LHS 粗扫 + 坐标下降），在应力/位移约束下最小化质量。 | CalculiX, 尺寸优化, 减重, LHS, 坐标下降 |
 

--- a/Skill/hypermesh/README.md
+++ b/Skill/hypermesh/README.md
@@ -1,0 +1,9 @@
+# HyperMesh Skills
+
+- [`hypermesh-evidence-meshing`](hypermesh-evidence-meshing): evidence-first
+  geometry cleanup, feature-aware partitioning, shell/solid meshing, and
+  quality remediation through the repository HyperWorks MCP.
+
+The skill contains no CAD, `.hm`, solver deck, generated mesh, or workstation
+configuration. Use project-scoped inputs and keep solver evidence outside the
+repository.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/SKILL.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: hypermesh-evidence-meshing
+description: Evidence-first Altair HyperMesh geometry cleanup, measured construction-line partitioning, shell/solid meshing, and mesh-quality remediation through Tcl and hmbatch. Use when Codex must plan or automate 2D quad flow, mapped/swept hexa blocks, tetra fallback, spheres, spherical shells, domes, flange plates, hubs, bolt circles/PCD, cylinders, holes, washers, slots, fillets, rounds, edge blends, chamfers, bevels, intersections, size transitions, biased edges, symmetry, contact or boundary regions, BatchMesher, solver-deck export, or repair of skew, Jacobian, warpage, aspect, angle, duplicate, and free-edge failures without reporting an empty or low-quality mesh as success.
+---
+
+# HyperMesh Evidence Meshing
+
+Use explicit Tcl through `hmbatch -tcl` as the reproducible baseline. Do not
+assume an undocumented Python API and do not modify vendor installation files.
+
+## Start
+
+Read `MCP/HyperWorks/README.md`, then call `get_environment`,
+`get_live_bridge_status`, and `get_live_capabilities`. Create a project with
+`create_project`, import only workspace-scoped inputs, and use one of two
+auditable routes:
+
+- write screened Tcl with `write_tcl_script`, then execute it with
+  `run_hmbatch`; or
+- use typed live operations such as `import_live_cad`,
+  `automesh_live_surfaces`, `solid_map_live_solids`,
+  `tetra_mesh_live_solids`, and `get_live_mesh_quality`.
+
+Use `create_live_checkpoint` before a local repair and
+`rollback_live_checkpoint` when any protected feature or active quality metric
+regresses. Inspect the installed release before using Tcl commands that are not
+covered by typed MCP tools. Never expose arbitrary Python, shell, or unscreened
+Tcl through the live bridge.
+
+## Choose the Meshing Route
+
+- For shells or midsurfaces, design quad flow and local transitions before
+  `automesh`; allow trias only where the solver and physics permit them.
+- For hex-dominant solids, prove each planned block is sweep/mapping-compatible
+  and define source, target, path, shared-face dependencies, and mesh order.
+- For tet-dominant solids, clean and protect the boundary surface mesh first;
+  do not over-partition merely to imitate a hex workflow.
+- Prefer a simpler, verifiable topology over a fragile pure-hex target when
+  decomposition cost or distorted transition blocks outweighs its benefit.
+
+## Gate the Workflow
+
+1. Copy source CAD into the run input area; never overwrite the original.
+2. Confirm the CAD reader/import completed and count imported surfaces/solids.
+3. Define solver-specific size and quality criteria, then audit free edges,
+   duplicate/overlapping surfaces, intersections, normals, and topology.
+4. Classify mesh-driving features and preserve intentional circular edges,
+   holes, contacts, loads, constraints, interfaces, and symmetry boundaries.
+5. Write a partition plan before cutting geometry. For each patch/block, record
+   why it exists, source/target/path topology, shared interfaces, and dependent
+   blocks. A large number of cuts is not evidence of a valid decomposition.
+6. Apply cuts incrementally. Re-check topology and mappability after each group
+   and reject sliver surfaces, short edges, acute wedges, and conflicting sweep
+   directions introduced by the cut.
+7. Define edge densities, local size, bias, washer rings, transition bands, and
+   sweep layers before generating dependent surface or volume mesh.
+8. Mesh difficult terminal/source regions first, then propagate compatible
+   shared-face meshes through dependent blocks. Generate verified surface mesh
+   before volume mesh when the route requires it.
+9. Diagnose failed elements by cause and node-to-geometry association. Cluster
+   failures, rank one hotspot at a time, and distinguish geometry-edge,
+   boundary-surface, and interior failures. Prefer topology repair or local
+   remesh before connectivity edits, and use node smoothing only when geometry
+   and topology are already suitable. Do not treat an absolute minimum-height
+   failure as an automatic request for a smaller local element size.
+10. When ordinary hotspot repair reaches a plateau, invoke the zero-failure
+    escalation route: checkpoint, test feature-aware shape-preserving morphing
+    on one/two neighboring layers, then route residual minimum-height and
+    interior-skew failures to separate local operations. Rank every candidate
+    globally and roll back regressions.
+11. Export `.hm`, solver deck, quality report, partition/feature summaries, and
+    command/log evidence.
+
+Read [references/quality-gates.md](references/quality-gates.md) before accepting
+the mesh. A return code of zero without entities and quality statistics is not a
+successful mesh.
+
+Read [references/partition-strategy.md](references/partition-strategy.md) before
+cutting 2D surfaces or decomposing a solid for mapped/swept hex meshing.
+
+Read [references/feature-meshing.md](references/feature-meshing.md) whenever the
+geometry includes cylinders, holes, circular/curved edges, slots, thin annuli,
+sweepable solids, fillets, steps, intersections, contacts, interfaces, or
+boundary-condition regions.
+
+Read [references/fillet-chamfer-meshing.md](references/fillet-chamfer-meshing.md)
+whenever the geometry contains interior fillets, exterior rounds, edge blends,
+chamfers, or bevels. Measure the profile, classify its physics role, derive
+curvature/row/transition controls, and verify protected boundaries and topology
+before accepting either preservation or defeaturing.
+
+Read [references/shape-partition-patterns.md](references/shape-partition-patterns.md)
+for spheres, spherical shells, domes, flange plates, hubs, bolt circles, or any
+revolved part that needs measured centers/axes, construction lines, concentric
+rings, meridians, symmetry planes, a non-collapsing core, or periodic sectors.
+
+Read [references/quality-remediation.md](references/quality-remediation.md) when
+QI or solver checks fail. Record the selected feature IDs, patch/block IDs,
+derived division counts, failed element sets, and before/after statistics; do
+not rely on a global element size or a final screenshot alone.
+
+Read [references/tetra-quality-optimization.md](references/tetra-quality-optimization.md)
+for any tetra route or tetra-quality failure. Export exact values with
+`hm_getelemcheckvalues`, localize overlapping failures, prove feature-to-gate
+feasibility, quality-check the boundary-tria mesh first, and reject node-only
+optimization when it plateaus or only renumbers failed elements.
+
+For a localized tetra repair, checkpoint the accepted mesh and process one
+hotspot as a transaction. Re-run every active metric globally after fixed-
+topology, edge-swap, or boundary-remesh candidates. Commit only a Pareto-safe
+candidate; otherwise reload the checkpoint. Recompute hotspot IDs after every
+accepted topology-changing operation because remeshing can invalidate element
+IDs and adjacency.
+
+For a hard zero-failure deliverable, all active failure counts must be zero in
+both the working model and an independently reloaded solver deck. Then audit
+pure element type, exact worst-value margins, moved boundary nodes, maximum
+displacement, and current/initial CAD associations. Numerical quality approval
+does not automatically approve geometry adherence; define and report an
+engineering displacement tolerance. Never force-project stale initial geometry
+IDs unless the referenced current entity exists and a checkpointed trial passes
+all quality and topology gates.
+
+## Finish
+
+Report source geometry type, import translator, entity counts, element counts,
+element types, global and local size controls, edge densities and bias, feature
+division counts, block dependency and meshing order, failed-quality counts,
+remediation, and exported solver profile. Preserve failed BatchMesher logs
+because they identify translator, criteria, parameter-file, or topology
+problems. For a zero-failure run, also report the independent-reload result,
+exact quality margins, maximum boundary displacement, the applicable geometry
+tolerance, and association changes.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/agents/openai.yaml
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "HyperMesh Feature & Quality Meshing"
+  short_description: "Measured partitions, blends, and mesh repair"
+  default_prompt: "Use $hypermesh-evidence-meshing to classify fillets, chamfers, and other features, plan measured patch or block topology, derive mesh controls, and apply evidence-gated quality remediation."

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/feature-meshing.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/feature-meshing.md
@@ -1,0 +1,167 @@
+# Feature-Aware Meshing
+
+Use this guide after choosing the mesh route and partition topology. Treat all
+counts as planning baselines; solver formulation, element order, contact,
+loading, curvature tolerance, and expected gradients govern final density.
+
+## Contents
+
+- Preserve, seed, washer, or remove
+- Circular edges and cylindrical surfaces
+- Holes, washers, and slots
+- Fillets, steps, ribs, and narrow faces
+- Intersections, spokes, and periodic geometry
+- Size transitions and biased edges
+- Feature evidence
+
+## Preserve, Seed, Washer, or Remove
+
+Classify every recognized feature by analysis role, not size alone:
+
+- **Preserve** holes/edges that define load transfer, bolts, pins, bearings,
+  contact, flow, materials, thickness, symmetry, loads, or constraints.
+- **Seed** a geometrically important feature when its boundary must be retained
+  but no dedicated ring or structured block is needed.
+- **Washer/O-grid** retained openings that need regular radial flow, connector
+  coupling, bearing/contact pressure, or controlled transition.
+- **Remove/suppress** cosmetic holes, logos, threads, short edges, chamfers, and
+  fillets only after documenting that their physics is negligible.
+
+Protect critical entities with explicit feature/preserved-entity selections.
+Do not let automatic cleanup collapse them merely because minimum element size
+is larger than the feature.
+
+## Circular Edges and Cylindrical Surfaces
+
+For radius `R`, target circumferential size `h_theta`, and maximum allowed angle
+per element `alpha_max`, calculate both baselines:
+
+```text
+n_size  = ceil(2*pi*R / h_theta)
+n_angle = ceil(360deg / alpha_max)
+n_theta = max(n_size, n_angle, minimum_count)
+```
+
+Round `n_theta` upward to satisfy periodic sectors, symmetry, opposing edges,
+and connector directions. A multiple of four is useful when quarter points or
+orthogonal directions must carry nodes, but it is not a universal quality rule.
+Give mating circles compatible counts and seam/start locations.
+
+For axial length `L`, use `n_z = ceil(L/h_z)` as a baseline. Bias axial layers
+toward shoulders, ends, contact boundaries, fillets, load introduction regions,
+or thickness changes. Record direction, minimum/maximum spacing, and growth.
+
+For annuli or thick cylinders, define radial layers from through-thickness
+physics. Split large curved sectors when the selected sweep direction forces a
+curved side to behave as a source/path combination that would otherwise produce
+distorted elements. Treat the community rule of splitting a 90-degree arc into
+two regions as a diagnostic heuristic, then verify scaled Jacobian and warpage.
+
+## Holes, Washers, and Slots
+
+For each retained hole, measure shape, radius/diameter, depth, axis, edge
+distance, neighboring-hole distance, and associated analysis feature.
+
+Choose the washer pattern deliberately:
+
+- **Radial washer** for circular flow and regular ring layers.
+- **Corner-quad washer** when the surrounding quad topology should connect to
+  four principal directions.
+- **No washer** when nearby boundaries, holes, or narrow ligaments make the ring
+  more distorted than a controlled local remesh.
+
+Define exact or minimum elements around critical holes; do not use `auto` when
+repeatable connector alignment or washer layers require a fixed count. Define
+one to three washer widths as absolute values, radius-based expressions, or
+quality-derived values. An automatic width may legitimately omit the washer
+when good elements cannot be produced, so verify actual creation.
+
+Prioritize bolt/bearing holes when washers overlap. For close holes or a hole
+near a free edge, build a shared partition/transition or relax the lower-priority
+washer. Report the minimum elements across the remaining ligament.
+
+For slots, keep the rounded or rectangular end treatment explicit. Seed both
+ends compatibly, match opposite straight-edge counts, and inspect skew at the
+arc/straight tangency. For blind or countersunk holes, independently inspect the
+wall, cap, cone/bottom transition, and sweep compatibility.
+
+## Fillets, Steps, Ribs, and Narrow Faces
+
+Read [fillet-chamfer-meshing.md](fillet-chamfer-meshing.md) for the complete
+measurement, preserve/suppress decision, fillet/chamfer calculation, Tcl
+realization, route-specific topology, and evidence workflow.
+
+Choose among four retained/simplified fillet treatments:
+
+- remove it when it is non-physical relative to target/minimum size;
+- preserve it with curvature control when stress or contact needs the radius;
+- split it along its midline to stabilize rows and mesh flow;
+- enforce a minimum row count across its arc length.
+
+Treat chamfers as measured narrow planar bands, not zero-radius fillets. Retain
+at least two controlled rows as a planning baseline when stress, contact,
+sealing, load transfer, or manufacturing intent matters; otherwise document and
+verify any suppression.
+
+Use chordal deviation/maximum angle and minimum element size together. Avoid
+capturing a radius with tiny elements that violate the solver minimum length.
+
+Suppress construction lines and narrow faces that create slivers, but preserve
+real steps and component boundaries. Do not preserve adjacent component
+boundaries that have no structural meaning if they force poor elements; do not
+remove meaningful interfaces merely to improve QI.
+
+At thickness changes, split a transition band instead of collapsing the entire
+change into one row. Keep step corners and contact edges as hard topology when
+they drive results.
+
+## Intersections, Spokes, and Periodic Geometry
+
+- At T/Y/pipe intersections, separate branch blocks from the main run and
+  establish a shared transition/core block before sweeping.
+- Around spokes, gear teeth, blades, or repeated sectors, mesh one verified
+  sector and replicate only when geometry, loading, contact, and periodic counts
+  are truly identical.
+- Align block seams with symmetry or low-gradient regions when possible; avoid
+  placing singular nodes in peak contact/stress zones.
+- Use a small three-direction mappable connector block where sweep directions
+  must change, rather than forcing conflicting one-direction blocks to meet.
+
+## Size Transitions and Biased Edges
+
+For fine size `h_f`, coarse size `h_c`, and maximum adjacent growth `g_max`, use:
+
+```text
+n_transition >= ceil(log(h_c / h_f) / log(g_max))
+g_actual = (h_c / h_f) ** (1 / n_transition)
+```
+
+Create an explicit transition band with enough distance/layers. Put topology
+singularities and unavoidable trias/pentas away from holes, contacts, sharp
+gradients, and shared sweep sources. Prefer symmetric bias when both ends need
+refinement and one-way bias when only one end is critical.
+
+Do not refine every boundary. Separate geometry-driven curvature refinement,
+physics-driven local refinement, and numerical transition requirements.
+
+For tetra routes, keep the regular model-level minimum size distinct from a
+smaller protected-feature minimum. A very small global curvature/proximity
+floor can capture every cosmetic short edge and sliver, creating many flattened
+tets. Use the finer value only on measured protected feature sets and verify the
+closed surface-tria mesh before volume meshing.
+
+## Feature Evidence
+
+Export, per feature:
+
+- stable ID or geometric descriptor and analysis role;
+- measured dimensions and units;
+- preserve/seed/washer/remove decision and reason;
+- local size, circumference count, washer type/width/layers, axial/radial
+  layers, bias/growth, and periodic/symmetry constraints;
+- selected entity count before the operation and created entity/element count;
+- localized quality failures before and after remediation.
+
+In Tcl, block execution when an expected feature selection is empty. Resolve
+actual commands and marks against the installed HyperMesh version; ribbon and
+Classic UI names differ and must not be used as proof that a Tcl command exists.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/fillet-chamfer-meshing.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/fillet-chamfer-meshing.md
@@ -1,0 +1,209 @@
+# Fillet and Chamfer Meshing
+
+Use this reference whenever a model contains interior fillets, exterior rounds,
+edge blends, chamfers, or bevels. Decide from analysis relevance and measured
+representability; never delete a feature only because it is small or keep it
+only because it exists in CAD.
+
+## Contents
+
+- Inventory and decision contract
+- Fillet calculations and topology
+- Chamfer calculations and topology
+- HyperMesh realization
+- Route-specific rules
+- Quality and evidence gates
+- Research basis
+
+## Inventory and Decision Contract
+
+Record, for every candidate feature:
+
+- stable surface/edge IDs, component, units, CAD or FE-geometry status, and
+  convex/concave classification;
+- analysis role: fatigue/stress concentration, contact, sealing, bearing/load
+  transfer, boundary condition, material/thickness interface, manufacturing,
+  or cosmetic;
+- minimum/maximum radius, profile width, included angle, longitudinal length,
+  tangency edges, adjacent-face widths, nearby holes/steps, and continuity;
+- global target size, solver minimum size, curvature angle, chordal-deviation
+  limit, cleanup tolerance, element order, and intended shell/hex/tet route.
+
+Use this decision order:
+
+1. **Preserve and control** a feature that affects contact, sealing, fatigue,
+   stress flow, load/constraint application, material/thickness boundaries, or
+   the source/target topology of a mapped block.
+2. **Preserve and test** a manufacturing feature when its result sensitivity is
+   unknown. Compare a locally converged retained model with any simplified
+   model before accepting suppression.
+3. **Suppress candidate** only when the feature is physically negligible and
+   its required rows would violate minimum size or create slivers. Suppression
+   is a reviewed decision, never an automatic result of this classification.
+4. **Manual review** a variable-radius blend, interrupted chain, blend running
+   into a hole/step/contact edge, or a feature whose adjacent faces cannot be
+   extended cleanly.
+
+Protect retained feature sets before BatchMesher or global cleanup. Confirm
+that loads, constraints, contacts, connectors, and property boundaries still
+reference valid entities after any geometry change.
+
+## Fillet Calculations and Topology
+
+For radius `R`, included/sweep angle `theta` in radians, target profile size
+`h`, maximum turn angle `alpha`, maximum chordal deviation `d`, and minimum
+profile rows `n_min`, calculate:
+
+```text
+arc_width = R * theta
+n_size    = ceil(arc_width / h)
+n_angle   = ceil(theta_deg / alpha_deg)
+n_dev     = ceil(theta / (2 * acos(1 - d/R)))       when 0 < d < R
+n_rows    = max(n_min, n_size, n_angle, n_dev)
+chord     = 2 * R * sin(theta / (2*n_rows))
+deviation = R * (1 - cos(theta / (2*n_rows)))
+```
+
+Treat two rows across a retained low-order fillet as a planning floor, not an
+acceptance rule. Use three or more rows, local convergence, or higher-order
+curvature representation when bending, fatigue, contact pressure, or a stress
+gradient drives the analysis. The actual angle need not be 90 degrees.
+
+For a structured shell mesh, connect both tangency edges and any longitudinal
+centerline to deliberate patch boundaries. Match counts along the fillet chain
+and adjacent patches. Put transitions outside the peak-gradient part of the
+fillet, and do not end a split line inside a mapped patch.
+
+A longitudinal centerline can stabilize row flow or split a narrow fillet into
+two controlled strips. It does not by itself guarantee quality: reject the
+split if it creates short end edges, distorted rows at hard points, or
+incompatible counts at an interrupted/variable-width chain.
+
+## Chamfer Calculations and Topology
+
+Treat a chamfer as a narrow planar feature band, not as a zero-radius fillet.
+Measure the shortest distance `s` across the chamfer face. If only the two leg
+setbacks `a` and `b` are known, derive:
+
+```text
+s        = sqrt(a*a + b*b)
+angle    = atan2(b, a)
+n_rows   = max(n_min, ceil(s / h))
+h_actual = s / n_rows
+```
+
+Use at least two rows across a retained structural/contact chamfer as a
+planning floor. Increase the count when contact traction, a weld preparation,
+sealing land, high stress gradient, or quadratic geometry representation needs
+it. A single row is acceptable only with explicit formulation and convergence
+evidence; it must not be a silent consequence of global size.
+
+For quads, extend the two chamfer endpoints/tangency-equivalent corners into
+the neighboring topology and match both long-edge counts. For mapped hex,
+isolate the chamfer and adjacent shoulder as a staged source-target block; do
+not force one axial sweep through a changing cross-section. Acute chamfers that
+leave wedge/sliver residual blocks require a revised cut or a tet/hybrid route.
+
+Suppress a cosmetic chamfer by merging/suppressing its bounding topology only
+after verifying that adjacent faces reconstruct cleanly. There is no assumption
+that every HyperMesh release exposes chamfers as a dedicated detected feature;
+manual narrow-face inventory may be required.
+
+## Size Transition
+
+When local profile size `h_f` must return to far-field size `h_c` with maximum
+adjacent growth `g_max`, create an explicit transition band:
+
+```text
+n_transition = ceil(log(h_c / h_f) / log(g_max))
+g_actual      = (h_c / h_f) ** (1 / n_transition)
+```
+
+Keep the transition out of tangency endpoints, contacts, load application
+zones, mapped source faces, and maximum stress-gradient regions. Re-run all
+quality metrics after changing density; do not repair a minimum-length failure
+by introducing skew, warpage, or a poor solid Jacobian.
+
+## HyperMesh Realization
+
+Use the installed-version UI or a command verified against its local help.
+
+1. Detect and review fillets with the Features tool, then validate the feature
+   data after geometry edits. Current feature data includes radius, width, and
+   angle ranges. Inventory chamfer faces separately when they are not detected.
+2. Measure the actual profile and classify preserve/suppress/manual-review
+   before changing geometry.
+3. For a retained fillet, use curvature-aware edge seeding and, when helpful,
+   split its longitudinal centerline. The documented Tcl operation is
+   `*createfilletmidlines`; its radius/width ranges and tangent-edge suppression
+   flag must be derived from measured values, not copied from an example.
+4. For a justified fillet removal, preview the selected chain. The documented
+   `*removeedgefillets` command filters surface edge fillets by radius and
+   angle; wrap it in `catch`, use explicit marks, and verify the post-operation
+   entity and topology counts.
+5. If automatic defeaturing fails, delete/reconstruct or extend/intersect the
+   adjacent CAD surfaces only in a copied run model. Check free/shared/non-
+   manifold edges and nearby topology immediately.
+6. For retained chamfers, create endpoint/section cuts and exact edge densities
+   before meshing the surrounding patch or block.
+7. Prefer the session command file or installed API documentation when mapping
+   a ribbon action to automation. UI labels and command signatures vary by
+   release.
+
+Do not apply CAD fillet/defeature commands to FE geometry without checking
+version support. Altair documents important FE-geometry limitations for
+Fillets, Defeature, Solid Map, tetra, and hex workflows in current releases.
+
+## Route-Specific Rules
+
+- **Shell/midsurface:** decide whether the physical 3D edge treatment belongs
+  in the midsurface idealization. Preserve a radius/chamfer when it changes the
+  midsurface path, thickness transition, joint, contact, or load definition.
+  Anchor feature and boundary nodes during smoothing.
+- **Mapped/swept hex:** isolate shoulder, fillet, and chamfer transitions into
+  compatible blocks. Check source mesh first, match shared-face counts, use
+  more than one layer through a retained profile, and verify scaled Jacobian,
+  aspect, warpage, and orientation after every staged sweep.
+- **Tet:** avoid hex-style over-partitioning. Retain a closed, intersection-free
+  boundary mesh with curvature/proximity controls; check boundary triangle
+  quality and tet collapse near small blends.
+- **Second order:** project/check midside nodes on retained curvature and repeat
+  the final-order quality checks. First-order chordal evidence is insufficient.
+
+## Quality and Evidence Gates
+
+Export before/after evidence containing:
+
+- feature IDs, measurements, role, decision, reason, and protected entities;
+- derived row count, actual chord/profile size, chordal deviation, local
+  transition layers/growth, and matching edge counts;
+- executed selection marks, detected/selected/changed entity counts, and any
+  command errors;
+- free/shared/non-manifold edges, shortest edge, narrowest face, surface/solid
+  counts, area/volume change, and bounding-box change after defeaturing;
+- failed count and worst value for minimum length, aspect, skew, warpage,
+  angle, Jacobian/scaled Jacobian, chordal deviation, and solver-specific checks;
+- local before/after images or element sets at tangency endpoints, fillet
+  centerlines, chamfer ends, block interfaces, and transition bands;
+- retained-vs-suppressed sensitivity evidence when the feature can affect peak
+  stress, contact pressure, sealing, stiffness, or fatigue.
+
+Block automatic acceptance if an operation loses a protected boundary,
+creates a free/non-manifold edge, produces required spacing below the solver
+minimum, leaves an unmappable residual block, or merely moves a severe failure
+into a more critical region.
+
+## Research Basis
+
+Community material supplied practical workflows; exact capabilities and Tcl
+signatures were cross-checked against Altair documentation:
+
+- [Bilibili double-fillet meshing example](https://www.bilibili.com/video/BV1HW4y1273B/)
+- [Bilibili HyperMesh geometry-cleanup and partition notes](https://www.bilibili.com/opus/1035259234909945926)
+- [Jishulink BatchMesher fillet controls and formulas](https://www.jishulink.com/post/421562)
+- [Altair Features: fillet detection, measurement, validation, and defeaturing](https://help.altair.com/hwdesktop/hwx/topics/pre_processing/model_setup/features_r.htm)
+- [Altair curved-surface mesh and chordal-deviation tutorial](https://2022.help.altair.com/2022.2/hwdesktop/hm/topics/tutorials/hm/hm_3120_2d_mesh_in_curved_surfaces_c.htm)
+- [Altair `*createfilletmidlines`](https://help.altair.com/hwdesktop/hwd/topics/reference/hm/_createfilletmidlines.htm)
+- [Altair `*removeedgefillets`](https://2022.help.altair.com/2022.3/hwdesktop/hwd/topics/reference/hm/_removeedgefillets.htm)
+- [Altair Quick Edit split, suppress, and trim operations](https://help.altair.com/2024/hwdesktop/hwx/topics/pre_processing/geometry/quick_edit_t.htm)
+- [Altair FE-geometry support limitations](https://help.altair.com/hwdesktop/hwx/topics/chapter_heads/fegeometry_r.htm)

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/partition-strategy.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/partition-strategy.md
@@ -1,0 +1,154 @@
+# Partition and Block Strategy
+
+Use partitioning to create meshable topology, not to maximize the number of
+geometric pieces. Every new edge/face must support mesh flow, feature capture,
+size transition, symmetry, or a valid source-target sweep relation.
+
+## Contents
+
+- Decide whether to partition
+- Plan 2D quad topology
+- Plan mapped/swept solid blocks
+- Decompose complex solids
+- Select and sequence cuts
+- Reject harmful partitions
+- Partition evidence
+
+## Decide Whether to Partition
+
+1. Fix the solver profile, element formulation/order, target/min/max size, and
+   quality criteria.
+2. Protect physics-driving features and identify candidates for suppression.
+3. Choose shell/quad, hex/sweep, or tet/boundary-surface route.
+4. Partition only if it improves one of these: patch sidedness, source-target
+   compatibility, edge-count compatibility, curvature capture, local transition,
+   feature isolation, symmetry, or mesh quality.
+5. Predict new short edges, sliver faces, acute corners, and interface conflicts
+   before applying the cut.
+
+For tet meshing, excessive decomposition usually adds boundary constraints and
+poor surface triangles. Prefer curvature/proximity controls unless partitioning
+is required for materials, contacts, boundary conditions, or local refinement.
+
+## Plan 2D Quad Topology
+
+Aim for four-sided or otherwise map-friendly patches with compatible opposing
+edge counts. Treat a geometric surface containing many trimmed edges as a
+topology problem even when it looks rectangular.
+
+Use these patterns:
+
+- Split around holes into washer/O-grid patches and connect their principal
+  directions to the outer boundary.
+- Extend important corners, tangent points, hole centers/quarter points, and
+  thickness transitions into deliberate partition lines.
+- Divide long irregular surfaces into a difficult feature patch, a transition
+  patch, and a regular far-field patch.
+- Suppress meaningless internal lines to merge tiny patches; add hard points or
+  split lines only when they control a needed node/flow location.
+- Keep unavoidable trias or extraordinary nodes in low-gradient, low-contact
+  regions and away from source faces used for hex mapping.
+
+Before meshing a patch, record its boundary loop, corner nodes, ordered edge
+counts, target flow direction, and neighboring patches. A quad-dominant surface
+is not acceptable if the flow twists abruptly or concentrates singularities at
+critical features.
+
+For a fine-to-coarse transition, cut a band with enough length for the permitted
+growth. Mesh the fine feature patch first, transition next, and regular coarse
+patch last. Do not ask smoothing to create a transition that the topology does
+not contain.
+
+## Plan Mapped/Swept Solid Blocks
+
+For every proposed block define:
+
+- source topology;
+- target topology;
+- path/along faces and sweep direction;
+- source and target boundary-loop correspondence;
+- divisions along the sweep;
+- shared faces and whether their mesh already exists;
+- one-direction or three-direction mappability expectation.
+
+Complex solids must be decomposed into simpler sweepable blocks before Solid
+Map. A three-direction mappable block is valuable where different sweep
+directions meet because it can accept multiple source-target choices. Do not
+assume all individually mappable solids can be meshed in a single multi-solid
+operation; incompatible constraints on a shared face can still require staged
+meshing.
+
+Use an existing, quality-checked 2D source mesh to control the resulting hex/
+penta topology. Maintain shared faces between adjacent blocks rather than
+detaching them unless a nonconformal interface is intentional.
+
+## Decompose Complex Solids
+
+Apply these heuristics in order:
+
+1. **Symmetry simplification:** partition and verify the smallest valid sector;
+   replicate only when geometry and analysis conditions share the symmetry.
+2. **Terminal-block backtracking:** identify a block that could be meshed last
+   even if its incoming interface mesh were already fixed. Remove it mentally,
+   repeat toward the core, then mesh in reverse dependency order.
+3. **Source-first difficulty:** mesh circular, highly constrained, or contact
+   source faces before simple rectangular neighbors; propagate their shared-face
+   topology outward.
+4. **Direction-change connector:** insert a compact three-direction mappable
+   block where one-direction sweep paths turn or branch.
+5. **Curved-sector split:** if a curved sector cannot sweep along its natural
+   arc and produces distorted path elements, split the sector into smaller
+   source/path roles and verify quality. The 90-degree bisection rule is a useful
+   community heuristic, not an unconditional geometric law.
+6. **Fallback:** use linear solid, drag/line-drag, ends-only, or a tet/hybrid
+   route when Solid Map topology is unsuitable. Record why the fallback is more
+   credible than additional fragile cuts.
+
+At T-, Y-, cross-pipe, spoke, gear, and branched structures, isolate branches,
+then solve the central junction topology. Do not sweep every branch independently
+into an unresolved core.
+
+## Select and Sequence Cuts
+
+Choose the least destructive cutter that creates the planned topology:
+
+- use an existing or constructed surface/plane for a complete sectional block;
+- use lines/edges for local surface partitions or to extend key directions;
+- use nodes/points to anchor a local cut or mapped corner;
+- preview extended trimmers and deselect unwanted split sections;
+- retain shared partition faces for conformal block interfaces.
+
+Apply cuts in small groups. After each group:
+
+1. verify topology colors/free/shared/non-manifold edges;
+2. recount solids/surfaces and expected shared faces;
+3. re-check mappability and source-target correspondence;
+4. measure the shortest new edge and narrowest new surface;
+5. undo/rework the group if it creates an unmeshable remainder.
+
+## Reject Harmful Partitions
+
+Reject or revise a plan when it:
+
+- creates a sliver smaller than solver minimum size;
+- turns a smooth transition into an acute wedge;
+- leaves a final residual block with no compatible source and target;
+- creates mismatched counts on a conformal shared face;
+- forces a washer, contact, or load boundary through a poor transition;
+- produces contradictory sweep directions at a shared face;
+- preserves cosmetic boundaries that destroy mesh flow;
+- removes component/material/contact boundaries solely to improve QI;
+- depends on global smoothing to repair invalid topology.
+
+## Partition Evidence
+
+Export a block/patch table containing:
+
+- block ID, purpose, bounding feature IDs, and parent solid/surface;
+- source, target, path, mappability expectation, and sweep direction;
+- ordered edge counts, bias, local size, and shared interface IDs;
+- predecessor/successor blocks and planned mesh order;
+- cutter type and selection counts;
+- post-cut entity counts, minimum new feature size, topology status, and actual
+  mappability;
+- accepted fallback or rejected-plan reason.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/quality-gates.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/quality-gates.md
@@ -1,0 +1,58 @@
+# HyperMesh Quality Gates
+
+- CAD import returns success and creates nonzero expected entities.
+- No unresolved duplicate surfaces, intersections, or unintended free edges remain.
+- The chosen shell/quad, hex/sweep, or tet route is justified against geometry,
+  solver formulation, analysis physics, and decomposition cost.
+- Every partition has a stated purpose and does not create unresolved sliver
+  surfaces, short edges, acute wedges, or residual unmappable blocks.
+- Mapped/swept blocks record source, target, path, shared-face dependencies,
+  sweep direction, and verified mappability before volume meshing.
+- Surface and volume element counts are nonzero.
+- Element type and solver profile match the downstream analysis.
+- Retained cylinders, holes, circular edges, contacts, interfaces, and
+  load/constraint boundaries have explicit local controls rather than only a
+  global size.
+- Mating or shared edges use compatible division counts; intentional
+  nonconformal interfaces name their coupling/contact method.
+- Washer, radial, axial, and biased transition layers record counts, direction,
+  minimum/maximum spacing, and growth ratio where applicable.
+- Quality metrics use named criteria: aspect ratio, skew, Jacobian, warpage,
+  minimum/maximum angle, tet collapse, or solver-specific checks.
+- Failed element counts and percentages are exported, not hidden.
+- Every metric also exports its exact worst value, element ID, centroid or
+  location, and ranked worst set; a failure threshold is not a worst value.
+- Tetra reports cross-correlate minimum-height, collapse, aspect, and volume-
+  skew sets and distinguish severe failures from marginal misses.
+- Tetra hotspot evidence reports node-to-geometry associations, boundary-node
+  count distribution, geometry IDs, cluster sizes, and local mesh-edge versus
+  associated geometry-edge lengths before choosing refinement.
+- Blind local refinement is blocked when an absolute minimum-height failure is
+  dominant and the hotspot is boundary constrained; boundary sampling and
+  surface-tria topology must be regularized or reviewed first.
+- Individual solver-specific metrics remain available when an aggregate QI is
+  reported; a better compound QI does not override a severe metric failure.
+- Quality remediation records the diagnosed cause, operation, affected patch,
+  and before/after counts and worst values.
+- Topology-changing local repair is checkpointed per hotspot, globally
+  rechecked, rolled back on an active-metric regression, and reclustered before
+  another element-ID-based operation.
+- A hard zero-failure tetra deliverable has zero failures for tet collapse,
+  aspect ratio, volumetric skew, minimum height, and any additionally active
+  Jacobian gate; it also contains no unintended non-tetra elements.
+- Zero-failure status is independently reproduced after solver-deck export and
+  reload. Record exact worst values and their safety margins, not only zeros.
+- Numerical quality acceptance and CAD-adherence acceptance are separate.
+  Record moved-node count, maximum boundary displacement, a user/engineering-
+  approved tolerance, and current/initial geometry-association changes.
+- Do not reproject nodes to stale initial point/line/surface IDs unless those
+  entities exist in the current model and a checkpointed trial preserves all
+  topology, feature, and quality gates.
+- A tetra volume is not repaired until its closed boundary-tria mesh has passed
+  topology and active 2D quality checks or its exceptions are documented.
+- Any quality exception is localized and justified.
+- Solver-deck export completes and the deck is nonempty.
+
+Block downstream solve claims when logs contain translator failure, nonzero
+`*geomimport` error code, BatchMesher nonzero return value, zero elements, or
+unresolved severe quality failures.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/quality-remediation.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/quality-remediation.md
@@ -1,0 +1,146 @@
+# Mesh Quality Diagnosis and Remediation
+
+Treat quality repair as a cause-driven loop. A visually smooth mesh is not
+proof of solver suitability, and a lower aggregate QI must not hide a severe
+solver-specific failure.
+
+## Contents
+
+- Establish criteria and localize failures
+- Diagnose the cause
+- Choose the least destructive remedy
+- Metric-specific remedies
+- Surface and solid checks
+- Verify and report
+
+## Establish Criteria and Localize Failures
+
+1. Load or define the downstream solver's 2D and 3D criteria before meshing.
+2. Align target size in meshing parameters with the target/min/max values in the
+   criteria file.
+3. Export failed count and percentage per metric, plus Worst/Fail/Warn/Good/Ideal
+   distributions when QI is used.
+4. Review failures as localized patches with one or more neighboring layers;
+   do not edit isolated elements without seeing their topology context.
+5. For tetra meshes, read [tetra-quality-optimization.md](tetra-quality-optimization.md),
+   export exact values with `hm_getelemcheckvalues`, and intersect the minimum-
+   height, collapse, aspect, and volumetric-skew failure sets.
+6. Count CAD-associated nodes in each failed tetra and classify connected
+   hotspots as geometry-edge, surface-boundary, interior, or mixed before
+   selecting refinement, edge swap, boundary remesh, or fixed-topology repair.
+
+QI is a weighted compound indicator. Retain the individual metric values and
+solver calculation method because different solvers and element types do not
+use one universal quality definition.
+
+## Diagnose the Cause
+
+Classify each failed patch before editing:
+
+- **geometry cause:** short edge, sliver face, duplicate/overlap, excessive
+  curvature, narrow gap, poor midsurface, or missing topology;
+- **partition cause:** wrong patch sidedness, incompatible counts, abrupt size
+  transition, singularity at a critical feature, or conflicting sweep paths;
+- **mesh connectivity cause:** poor diagonal, unnecessary trias, duplicate
+  elements, disconnected/equivalent nodes, or wrong local pattern;
+- **node-position cause:** otherwise valid topology with locally suboptimal node
+  locations;
+- **formulation/criteria cause:** inappropriate element type/order, impossible
+  minimum length, or criteria inconsistent with target size.
+
+Repair the highest-level cause first. Repeated node motion cannot cure a sliver
+surface or an invalid hex block.
+
+## Choose the Least Destructive Remedy
+
+Apply remedies in this order unless evidence justifies another sequence:
+
+1. correct duplicate, overlap, free-edge, normal, or topology errors;
+2. suppress/protect/split geometry and revise local density or transition;
+3. remesh the localized patch/block while preserving valid interfaces;
+4. change connectivity with split, swap, or combine operations;
+5. smooth/move nodes with geometry association and anchor constraints;
+6. accept an exception only with solver evidence and localized justification.
+
+When smoothing, anchor critical feature, interface, connector, and boundary
+nodes. Review whether selected nodes are fixed by geometry, 1D elements, or
+unselected neighbors; an unchanged mesh may mean the intended nodes cannot move.
+
+## Metric-Specific Remedies
+
+| Failure | Likely cause | Preferred remedy |
+| --- | --- | --- |
+| Minimum length | short geometric edge, over-refinement, collapsed transition | suppress/repartition the feature, change density/transition, then local remesh |
+| Maximum length | insufficient local density | refine the patch or edge and transition outward |
+| Aspect ratio | narrow patch, mismatched opposite counts, one-row transition | repartition, align flow, add rows, or revise edge counts |
+| Skew | diagonal/connectivity or distorted flow around a feature | swap edge, revise washer/transition, split surface, local remesh |
+| Warpage | coarse curved surface, poor midsurface, nonplanar quad | improve geometry/midsurface, curvature refinement, split or local remesh |
+| Jacobian/scaled Jacobian | distorted mapped source, twisted sweep, collapsed solid | repair source mesh/block decomposition and remesh; do not rely on smoothing alone |
+| Min/max angle | acute patch corner, bad tria/quad diagonal | revise partition, split/swap/combine, then smooth locally |
+| Tet collapse | poor boundary triangles, narrow volume, proximity conflict | repair surface mesh/geometry, adjust volume controls, regenerate the affected volume |
+| Excess trias/pentas | unsuitable quad/hex topology or transition | move singularity, repartition, combine compatible trias; keep allowed transitions if quality improves |
+| Duplicate elements/nodes | repeated generation or unsafe equivalence | identify duplicates, delete the intended copy, equivalence only within justified tolerance |
+
+Do not chase one metric while degrading another. Re-run all active checks after
+each local patch repair.
+
+## Surface and Solid Checks
+
+For shell/surface mesh, verify topology/free edges, normals, geometry
+association, duplicate elements, edge flow, size grading, and feature capture.
+
+For mapped hex/penta mesh, verify source surface quality before extrusion,
+source-target correspondence, shared-face continuity, sweep-layer bias, element
+orientation, scaled Jacobian/Jacobian, aspect, warpage, and any solver-specific
+solid checks. A mappable color/status proves topology eligibility, not final
+quality.
+
+For tet mesh, verify a closed, intersection-free surface mesh before volume
+generation. Recheck boundary triangles and local proximity after failed tet
+collapse or volume meshing.
+
+For second-order elements, project/check midside nodes as required and repeat
+quality checks using the final order; first-order quality alone is insufficient.
+
+## Verify and Report
+
+After each remediation iteration, export:
+
+- operation, selected patch/block and neighboring layers;
+- before/after element and node counts;
+- before/after failed count, percentage, worst value, and location per metric;
+- any moved boundary/feature nodes and maximum displacement;
+- newly created trias/pentas or changed connectivity;
+- remaining exception sets and engineering justification.
+
+Stop automatic cleanup when improvements plateau, failures migrate into more
+critical regions, or an operation violates feature/interface constraints. Block
+acceptance when severe solver-specific failures remain unresolved.
+
+Apply local topology changes as checkpointed transactions. Process one hotspot,
+re-run all active metrics globally, and reload the checkpoint if any protected
+feature, failure count, or exact worst value regresses. Recompute the failure
+clusters after every accepted topology change rather than reusing stale element
+IDs.
+
+Treat less than one-percent improvement in the dominant failure count as a
+plateau unless the exact worst value or critical-region location improves
+materially. Do not repeat a node-only optimizer after this point; revisit the
+geometry, boundary trias, local controls, and remesh freedom.
+
+For a boundary-dominated tetra plateau, add a controlled shape-preserving
+escalation before destructive surface reconstruction: checkpoint the best mesh,
+test feature-aware `*morphsmoothmorphbased` candidates over one and two
+neighboring layers, and rank them by all active failures, exact margins,
+protected-feature integrity, and boundary displacement. After this broad
+regularization, repair only the remaining typed residuals: a one-layer local
+free-morph candidate for minimum-height clusters and fixed-boundary local
+tetra remeshing for interior skew/connectivity clusters. Independently reload
+the exported deck before accepting zero failures.
+
+The least failed mesh is not automatically the least distorted geometry.
+Always compare node coordinates against the accepted baseline, distinguish
+boundary and interior motion, set a documented displacement tolerance, and
+audit both current and initial CAD associations. Reject forced projection when
+the referenced current geometry entity is unavailable or when the trial
+creates degenerate elements.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/shape-partition-patterns.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/shape-partition-patterns.md
@@ -1,0 +1,276 @@
+# Sphere and Flange Partition Patterns
+
+Use this reference for spheres, spherical shells, domes, flange plates, hubs,
+and other revolved parts whose mesh quality depends on measured construction
+lines and repeatable block topology. The patterns are planning baselines, not a
+substitute for solver-specific convergence and quality checks.
+
+## Contents
+
+- Measurement contract
+- Construction-line rules
+- Sphere and spherical-shell pattern
+- Flange and bolt-circle pattern
+- HyperMesh realization sequence
+- Acceptance evidence
+- Research basis
+
+## Measurement Contract
+
+Do not infer a partition from appearance alone. Record stable geometry IDs,
+units, tolerance, and the method used to obtain each dimension.
+
+For a sphere, spherical shell, or dome, measure:
+
+- center and local orthogonal axes;
+- outer and inner radius, shell thickness, and opening/cut-plane locations;
+- included polar/azimuth angles for a partial sphere or dome;
+- symmetry planes, seams, contacts, load patches, and support boundaries;
+- smallest fillet, opening, ligament, and expected high-gradient region.
+
+For a flange or hubbed plate, measure:
+
+- center, axis, outer radius, bore radius, and every step/shoulder radius;
+- pitch-circle diameter/radius (PCD), bolt-hole diameter, count, angular phase,
+  and whether holes are through, blind, counterbored, or countersunk;
+- flange, hub, neck, gasket, and washer/contact thicknesses;
+- adjacent-hole center distance and clear ligament;
+- radial clearance from each hole to the bore/hub and outer rim;
+- fillet/chamfer radii, mating faces, gasket band, contact faces, load points,
+  and constraints.
+
+Use HyperMesh Measure for length, angle, radius, area, volume, center of gravity,
+and bounding-box checks. Snap to end, middle, center, tangent, perpendicular, and
+intersection locations where supported. Cross-check a recognized circle with
+three non-collinear points or detected feature data; do not build a bolt pattern
+from a visually estimated center.
+
+For `N` equally spaced holes on pitch radius `R_p` with hole radius `r_h`,
+calculate:
+
+```text
+pitch_angle       = 360deg / N
+center_chord      = 2 * R_p * sin(pi / N)
+tangent_ligament  = center_chord - 2 * r_h
+inner_clearance   = (R_p - r_h) - R_bore
+outer_clearance   = R_outer - (R_p + r_h)
+```
+
+Negative or near-zero clearance is a geometry/topology blocker, not a mesh-size
+problem. Report the number of intended element rows across every critical
+ligament and contact band.
+
+## Construction-Line Rules
+
+Construction lines are mesh-control topology. Keep only lines that establish a
+required mapped corner, feature ring, transition band, source/target boundary,
+symmetry seam, contact boundary, or load location.
+
+1. Establish a verified local coordinate system at the measured center/axis.
+2. Create points at measured centers, quadrant/extreme locations, tangent
+   points, step radii, and sector boundaries.
+3. Create circles/arcs, radial lines, meridians, or sectional planes from those
+   points and dimensions.
+4. Project lines onto the intended surface along an explicit vector or surface
+   normal. Confirm the projected line remains on the correct face.
+5. Preview extended trimmers and select only intended split sections.
+6. Split in small groups, then re-check free/shared/non-manifold edges,
+   shortest new edge, narrowest patch, patch sidedness, and solid mappability.
+7. Suppress redundant hard points and construction edges after they have served
+   their purpose, unless they must remain as a boundary or mesh-density anchor.
+
+Prefer full planes/surfaces for complete solid sections and local projected
+lines for surface-only flow control. An auxiliary line that stops in the middle
+of a mapped patch usually creates a T-junction or residual sliver; terminate it
+at a deliberate block boundary or remove it.
+
+## Sphere and Spherical-Shell Pattern
+
+### Choose the topology
+
+- **Tet sphere:** retain a clean curvature-controlled boundary and avoid hex-
+  style internal cuts unless material, contact, load, or refinement regions
+  require them.
+- **Quad-dominant spherical shell:** use symmetry patches or a six-patch
+  cube-projected layout. A latitude/longitude grid concentrates nodes and poor
+  aspect ratios at the poles; do not accept it merely because it looks regular
+  away from the pole.
+- **All-quad spherical shell:** prefer six four-sided projected patches with
+  matching counts. If eight spherical octants are used, explicitly design the
+  extraordinary-node/transition topology instead of treating each triangular
+  octant as a mapped four-sided face.
+- **Mapped-hex solid sphere:** create a finite cube-like core and six surrounding
+  curved blocks, or an equivalent non-collapsing multiblock layout. Do not drag
+  an entire spherical surface to one center node; the collapsed center produces
+  degenerate/low-Jacobian cells.
+- **Spherical shell solid:** partition outer and inner faces identically, match
+  their loops and counts, then map/sweep through thickness.
+
+### Create measured auxiliary topology
+
+1. Create three orthogonal planes through the measured center and verify one
+   eighth of the geometry when symmetry of geometry and analysis permits.
+2. Create great-circle/equator and meridian curves from those planes. Use them
+   as symmetry or patch boundaries, not as an automatic latitude/longitude
+   mesh generator.
+3. For a six-patch shell, project a centered cube's six face boundaries onto
+   the sphere and verify four-sided patch loops and equal shared-edge counts.
+4. For a solid sphere, define a nonzero core radius and create the core before
+   connecting its faces to the spherical boundary. Keep core edges comparable
+   to the first outer radial layer.
+5. Add local rings only around openings, contacts, loads, or refinement zones.
+   Stop the ring through a transition patch before it reaches a pole or a
+   conflicting seam.
+6. Mesh one verified patch/octant first. Replicate only if geometry, material,
+   contacts, loads, and constraints preserve the same symmetry.
+
+For radius `R`, target surface size `h`, maximum angular increment `alpha`, and
+required count multiple `m`, use:
+
+```text
+n_size       = ceil(2*pi*R / h)
+n_angle      = ceil(360deg / alpha)
+n_great      = round_up(max(n_size, n_angle, minimum_count), m)
+n_quarter    = n_great / 4
+n_semicircle = n_great / 2
+```
+
+Make `m` compatible with four quadrant directions and every modeled symmetry or
+periodic sector. This is a count baseline; increase it for contact, local
+curvature, bending, wave propagation, or convergence requirements.
+
+### Sphere rejection checks
+
+Reject or revise the plan when:
+
+- radial lines converge to a single center or polar node;
+- a cube-like core is so small that the first outer block has a severe size
+  jump, or so large that its projected outer cells become highly skewed;
+- shared cube/sphere patch edges have incompatible counts or seam starts;
+- a pole, extraordinary node, or block seam lies inside peak contact/load/stress
+  regions without a documented reason;
+- shell thickness has too few layers for the selected formulation and physics;
+- replication is used although openings, loads, constraints, or contact break
+  symmetry.
+
+## Flange and Bolt-Circle Pattern
+
+### Partition by functional radial zones
+
+Use only zones that exist and matter in the model:
+
+1. bore/shaft interface;
+2. hub or neck and its fillet/shoulder transition;
+3. inner ligament from hub/bore to the bolt-hole band;
+4. bolt-hole washer/contact band;
+5. outer ligament and rim;
+6. gasket/contact/load bands on the flange face;
+7. axial flange, hub, neck, and step layers for a solid model.
+
+Create concentric circles at the bore, hub shoulder, physical gasket/contact
+limits, washer limits, transition limits, and outer rim. Do not create every
+possible ring: overlapping rings or a ring closer than the allowed minimum size
+produce sliver annuli.
+
+Create radial auxiliary lines through every bolt-hole center and at every
+mid-pitch plane. Add quadrant/tangent connections from each retained hole to
+its washer boundary so each hole patch has compatible principal directions.
+Where the hub or outer boundary interrupts this flow, end the lines at a
+purpose-built transition circle and redesign the far-field patch counts.
+
+### Sector and 3D mapping logic
+
+- A one-pitch sector spans `360/N` degrees. Use it as an analysis sector only
+  when geometry, material, gasket/contact, bolt pretension, loads, and
+  constraints are cyclically identical.
+- Even without cyclic analysis, a verified sector may be patterned as mesh
+  topology. Equivalence and re-check every sector seam.
+- Mesh hole/washer patches first, radial transition zones second, regular rim
+  and bore/hub zones third.
+- For a constant-thickness flange solid, quality-check one face mesh and sweep
+  it axially. Isolate hub/neck steps and fillets into separate source-target
+  blocks before the sweep.
+- A varying-thickness or necked flange usually needs staged blocks; do not force
+  a single axial drag across a shoulder or fillet.
+- Use shells/midsurfaces only when the chosen formulation represents flange
+  bending, contact, bolt load introduction, and thickness offsets adequately.
+
+For each hole, derive an explicit circumferential count from size and curvature
+and round it to a multiple of four when quadrant connections are required. Make
+the pitch-circle and sector-boundary counts multiples of the hole count so
+patterned seams remain compatible.
+
+### Flange rejection checks
+
+Reject or revise the plan when:
+
+- a hole washer overlaps the bore, hub shoulder, adjacent washer, gasket limit,
+  or outer rim without a shared transition plan;
+- fewer than the solver/physics-required rows fit across an inner, outer, or
+  adjacent-hole ligament;
+- the hole-center and mid-pitch lines produce different edge counts on opposite
+  sector boundaries;
+- a mesh seam crosses a bolt bearing patch, gasket discontinuity, contact edge,
+  or concentrated load unnecessarily;
+- an axial sweep crosses a step/fillet with incompatible source-target loops;
+- a cyclic sector is replicated despite nonperiodic pretension, loading,
+  contact, material, or geometry.
+
+## HyperMesh Realization Sequence
+
+Use the installed-version ribbon or verified Tcl equivalents:
+
+1. Detect/review holes and flanges and store their dimensions/descriptors.
+2. Measure and record radii, angles, thicknesses, centers, clearances, area/
+   volume, and bounding box as applicable.
+3. Create points/nodes and local systems at verified centers, extrema, tangent
+   locations, sector boundaries, and axial stations.
+4. Create lines/arcs/circles and sectional planes/surfaces.
+5. Use Split with Lines for projected or offset surface splits, including
+   washer anchors, and Split with Planes/Surfaces for complete solid blocks.
+6. Review split sections and apply only the intended trims.
+7. Verify topology/mappability and count new entities before meshing.
+8. Set exact shared-edge densities, bias, local size, curvature angle, washer
+   layers, and through-thickness/sweep divisions.
+9. Mesh one patch/block/sector, check all active metrics, then propagate.
+
+Do not translate UI labels directly into Tcl. Resolve commands against the
+installed HyperMesh help and capture the executed commands, marks, and entity
+counts in the run evidence.
+
+## Acceptance Evidence
+
+Add these items to the normal partition and quality reports:
+
+- measured center/axis/radii/PCD/thickness table with units and tolerance;
+- construction entity table with point, line, plane, and target IDs;
+- before/after split entity counts and minimum new edge/patch width;
+- sphere patch/core layout or flange radial-zone/sector layout;
+- ordered counts at every shared patch/block/sector edge;
+- minimum elements across shell thickness and flange/hole ligaments;
+- source-target-path, mesh order, symmetry/periodicity justification, and seam
+  equivalence result;
+- local Jacobian, warpage, aspect, skew, angle, and solver-specific failures at
+  poles, core interfaces, holes, washers, fillets, seams, and transitions.
+
+## Research Basis
+
+Community examples were used to identify practical patterns, then topology and
+operations were cross-checked against Altair documentation:
+
+- Bilibili sphere structured-mesh and multi-scale circular examples show the
+  recurring sphere/circular training patterns.
+- A HyperMesh sphere example on Jishulink explicitly uses one-eighth symmetry.
+- Altair China block-decomposition teaching and the “partition art” notes cover
+  mappability, terminal-block backtracking, symmetry, and curved-sector splits.
+- Community HyperMesh notes describe constructing points/nodes and projected
+  lines before using shared edges to split geometry.
+- Altair Measure documents length, angle, radius, area, volume, center-of-
+  gravity, bounding-box, and snap-based measurement.
+- Altair Features documents detection and management of 2D/3D holes, flanges,
+  fillets, and associated geometry/mesh.
+- Altair Split with Lines supports lines, bounding lines, offset/washer splits,
+  graphical lines, projection, and section preview; Split with Planes supports
+  complete surface/solid sections.
+- Altair Solid Map requires complex solids to be partitioned into simpler
+  mappable sections and still requires staged meshing and quality checks.

--- a/Skill/hypermesh/hypermesh-evidence-meshing/references/tetra-quality-optimization.md
+++ b/Skill/hypermesh/hypermesh-evidence-meshing/references/tetra-quality-optimization.md
@@ -1,0 +1,213 @@
+# Tetra Quality Optimization
+
+Use this reference for first- or second-order tetra meshes when minimum height,
+tet collapse, aspect ratio, volumetric skew, or a solver-specific 3D criterion
+fails. The workflow is surface-first and cause-driven: exact values and failed
+patches are evidence; a smoother-looking mesh is not.
+
+## 1. Audit Exact Values, Not Only Failure Counts
+
+For every active metric export the threshold, direction, failed count, failed
+rate, exact worst value, worst element ID, centroid, and a ranked worst-element
+list. HyperMesh documents `hm_getelemcheckvalues mark_id 3 check_type` for this
+purpose. Useful 3D `check_type` values include `minlength`, `tetracollapse`,
+`aspect`, `volumetricskew`, and `jacobian`.
+
+```tcl
+*createmark elems 1 all
+set collapse_values [hm_getelemcheckvalues 1 3 tetracollapse]
+set height_values   [hm_getelemcheckvalues 1 3 minlength]
+set aspect_values   [hm_getelemcheckvalues 1 3 aspect]
+set skew_values     [hm_getelemcheckvalues 1 3 volumetricskew]
+set jacobian_values [hm_getelemcheckvalues 1 3 jacobian]
+```
+
+Do not infer the worst value from the failure threshold. Keep the HyperMesh
+check method and solver profile in the report because quality definitions can
+change with the selected method. For linear tetra elements, a Jacobian value of
+one can coexist with poor collapse or skew and does not overrule them.
+
+In addition to the worst value, report meaningful distributions. At minimum,
+split minimum-height failures into `<0.25*gate`, `0.25-0.5*gate`,
+`0.5-0.75*gate`, and `0.75-1.0*gate`, then distinguish severe degeneracy from
+marginal misses.
+
+## 2. Localize and Cross-Correlate Failed Patches
+
+1. Export every failed element ID/value/centroid per metric.
+2. Group failures by face/edge adjacency or a radius related to local size; add
+   at least one neighboring layer before remediation.
+3. Intersect metric sets. If every collapse/aspect/skew failure is contained in
+   the minimum-height set, repair their common geometric or boundary-triangle
+   cause first.
+4. Map clusters to CAD surface/edge IDs and identify short edges, sliver faces,
+   narrow gaps, small fillets/chamfers, hole ligaments, intersections, contacts,
+   load/constraint regions, material interfaces, and symmetry boundaries.
+5. Record whether the worst element is on the boundary or inside the volume and
+   whether adjacent surface trias already fail size, angle, aspect, or skew.
+
+Repeated optimizer runs that merely renumber bad elements are not improvement.
+Reject a run when the dominant failure count improves by less than one percent,
+another metric worsens, or failures migrate into a more critical region.
+
+### Classify Hotspots Before Choosing Refinement
+
+For every failed tetra, record the number of nodes associated with CAD points,
+lines, or surfaces by `hm_getnodegeometry`. Also record the associated geometry
+IDs, total geometry-line length, local mesh-edge lengths, and one or two
+neighboring element layers. Use `hm_getnearbyentities` when a proximity search
+is more reliable than direct node association in the current representation.
+
+Classify each connected/spatial hotspot before changing element size:
+
+- **geometry-edge driven:** most failed tets have three boundary nodes or share
+  the same line/point IDs. Inspect local node spacing, tangent discontinuity,
+  endpoints, and feature role. Redistribute or coarsen irregular edge seeding,
+  or reconstruct non-physical topology; do not automatically split the already
+  short height into smaller tets;
+- **surface-boundary driven:** most failed tets have two or three boundary
+  nodes. Check boundary-tria angle, aspect, skew, minimum normalized height,
+  curvature adherence, and transitions. Test fixed trias, edge swap, and
+  boundary remesh as separate candidates with geometry edges, feature lines,
+  interfaces, and anchors protected;
+- **interior driven:** most failed tets have zero or one geometry-associated
+  node. Try fixed-boundary connectivity/node optimization before changing CAD
+  density;
+- **mixed:** separate boundary and interior subclusters instead of sending the
+  full union to one optimizer call.
+
+Refinement is allowed only when protected curvature, contact/load/fatigue
+physics, or a demonstrated solution-gradient error is under-resolved and the
+new fine zone has an explicit transition. When minimum height is the dominant
+absolute gate and at least 60% of failed tets have two or more boundary nodes,
+block blind refinement by default: a smaller target size can lower absolute
+tetra height even if the mesh looks denser.
+
+### Transactional Per-Hotspot Repair
+
+1. Rank hotspots by severe worst values, overlapping metrics, protected physics
+   role, boundary-node ratio, and size.
+2. Save a checkpoint of the currently accepted mesh.
+3. Repair one hotspot plus one neighboring layer. Add a second layer only when
+   the transition has insufficient freedom.
+4. Re-run every active metric over the full model and compare failure counts,
+   exact worst values and locations, not only the seed metric.
+5. Commit only a strict Pareto improvement by default. If any active count or
+   worst value regresses, reload the checkpoint and record the rejected route.
+6. Re-export/recluster failures after an accepted edge swap or remesh because
+   element IDs and adjacency can change.
+
+Use `get_live_mesh_quality` to capture the accepted baseline and
+`create_live_checkpoint` before each hotspot transaction. Apply only typed
+repair operations supported by the installed HyperWorks MCP; otherwise write a
+screened, version-checked Tcl script and retain its log. Use
+`rollback_live_checkpoint` whenever the global comparison rejects a candidate.
+
+### Zero-Failure Escalation After a Plateau
+
+Use this escalation only when ordinary surface-first and per-hotspot repairs
+stop improving yet the deliverable requires zero failed elements.
+
+1. Checkpoint the best globally accepted mesh and export the current exact
+   values, intersections, boundary-node ratios, and geometry associations.
+2. When at least 90% of residual failed elements are boundary associated, test
+   feature-aware `*morphsmoothmorphbased` candidates over one and two neighboring
+   layers with quality levels 2 and 3 and protected anchors/interfaces.
+3. Rank candidates lexicographically by total active failure counts, exact
+   worst-value margins, protected-feature preservation, element/type counts,
+   and boundary displacement. Roll back every regression.
+4. Recluster after the accepted broad step. Use a one-layer shape-preserving
+   local free-morph trial for remaining minimum-height clusters. Use fixed-
+   boundary local `*tetmesh` mode 6 for residual interior skew/connectivity.
+   Mode 7 is a swappable-boundary trial and mode 8 a remeshable-boundary trial;
+   keep `min_height` active and verify command syntax for the installed release.
+5. Export and independently reload the solver deck. Require zero failures again,
+   pure intended element type, and identical entity/count evidence.
+6. Audit moved nodes, maximum boundary displacement, current/initial CAD
+   association changes, and an explicit engineering geometry tolerance.
+
+Do not force-project stale initial point/line/surface IDs. First prove that the
+referenced geometry entities exist in the current database, then use a
+checkpointed projection candidate and reject it if any quality, topology, or
+feature gate regresses.
+
+## 3. Check Geometry-to-Criteria Feasibility
+
+Before meshing, compare these quantities in one table:
+
+- smallest retained edge and narrowest retained face;
+- smallest protected fillet/chamfer profile and hole ligament;
+- target surface size and global minimum size;
+- local protected-feature size and allowed growth;
+- minimum-height/length quality gate.
+
+If a retained feature is approximately equal to or smaller than the
+minimum-height gate, there is no robust geometric margin. Choose one reviewed
+route:
+
+- preserve it and use an explicit local control plus a retained-versus-
+  simplified sensitivity/convergence study;
+- reconstruct or suppress it only when its physics role is negligible;
+- revise the criterion only with downstream solver/formulation justification.
+
+Do not apply the smallest curvature size globally. As a BatchMesher planning
+baseline, Altair recommends a minimum size near 33% of target size, with roughly
+40-50% still practical in some cases. Use this as a regular-surface baseline,
+not a universal law. Put smaller sizes only on protected holes, blends,
+contacts, or result-sensitive regions and transition outward explicitly.
+
+## 4. Surface-First Remediation Sequence
+
+Apply this order:
+
+1. Repair free/T/non-manifold edges, intersections, overlaps, duplicate faces,
+   bad normals, sliver surfaces, and unprotected cosmetic short edges.
+2. Classify every small hole, fillet, chamfer, and narrow face as protected,
+   local-control, sensitivity-study, or suppression candidate. Never automatic-
+   suppress unknown load/contact/fatigue features.
+3. Generate the closed surface-tria mesh first. Check free/T-edges, duplicates,
+   minimum normalized height/size, aspect, skew, min/max angle, curvature
+   adherence, and transition quality before tetra generation.
+4. Use a regular model-level size range. Add surface-deviation, angle-based,
+   hole/washer, fillet, proximity, and local-size controls only to measured
+   feature sets. Prefer a local fine band with growth at or below about 1.25
+   when the original 1.3 transition contributes abrupt flat tets.
+5. Generate the affected tetra volume with the installed-version options for
+   minimum-height restriction and quality optimization. Preserve anchors and
+   required boundaries.
+6. If failures remain, remesh the failed cluster plus neighbors. In Solid Mesh
+   Optimization, boundary-triangle `Remesh` usually offers more freedom than
+   fixed triangles or edge swaps; protect feature lines, component interfaces,
+   geometry edges, and anchor nodes.
+7. Re-run every active metric and compare exact worst values, counts, locations,
+   element count, time, geometry adherence, and moved boundary nodes.
+
+Node smoothing or tetra optimization belongs after geometry and boundary-tria
+repair. It cannot remove a CAD sliver or create transition distance that the
+surface topology does not provide.
+
+## 5. Acceptance Contract
+
+Block automatic acceptance unless all of the following hold:
+
+- exact worst values and IDs exist even for metrics with zero failures;
+- all active solver-specific failure counts are zero, or each residual
+  exception is localized and backed by solver evidence;
+- no protected feature, contact, load, constraint, material, or interface
+  entity was lost;
+- geometry volume/bounding-box deviation and free/non-manifold topology remain
+  within documented tolerances;
+- no metric improves by hiding a worse value in another criterion;
+- any removed stress/contact/fatigue feature has sensitivity or convergence
+  evidence;
+- the final-order mesh is checked after second-order conversion when used.
+
+## Research Basis
+
+- [Altair tetra-meshing tutorial: curvature/proximity, defeaturing, surface-first mesh, and mesh controls](https://2025.help.altair.com/2025/hwdesktop/hwx/topics/tutorials/hwx/tetrameshing_t.htm)
+- [Altair Solid Mesh Optimization: boundary remesh, anchors, feature lines, and rejection](https://2025.help.altair.com/2025/hwdesktop/hwx/topics/pre_processing/meshing/solid_mesh_optimization_t.htm)
+- [Altair `hm_getelemcheckvalues` command](https://2025.help.altair.com/2025/hwdesktop/hwd/topics/reference/hm/hm_getelemcheckvalues.htm)
+- [Altair element-quality definitions for minimum height, tet collapse, aspect, and volume skew](https://2025.help.altair.com/2025/hwdesktop/cfd/topics/pre_processing/meshing/element_quality_calculations_hypermesh_r.htm)
+- [Altair BatchMesher criteria/parameter best practices](https://2025.help.altair.com/2025.1/hwdesktop/hwx/topics/pre_processing/meshing/batchmesher_criteria_parameter_best_practices_r.htm)
+- [Bilibili Solid Mesh Optimization notes](https://www.bilibili.com/opus/992617012877328386): practical emphasis on surface-mesh quality and local remesh/optimization; exact commands and definitions were cross-checked against Altair documentation.
+- [Bilibili HyperMesh quality-check and tetra-workflow course](https://www.bilibili.com/video/BV1Mh4y117nQ/): community workflow reference; numerical rules were not accepted without official cross-checking.

--- a/Subagent/hypermesh-meshing.md
+++ b/Subagent/hypermesh-meshing.md
@@ -9,6 +9,12 @@ Use this subagent when a task requires a real, auditable HyperMesh mesh rather
 than a generic explanation of meshing theory. It coordinates the installed
 HyperWorks MCP and does not assume an undocumented HyperMesh Python API.
 
+Before execution, read the repository
+[`hypermesh-evidence-meshing`](../Skill/hypermesh/hypermesh-evidence-meshing/SKILL.md)
+skill. Load its partition, feature, fillet/chamfer, shape-pattern, remediation,
+tetra-optimization, and quality-gate references only when the geometry or
+failure mode requires them.
+
 ## Required Inputs
 
 Collect or explicitly mark unknown:
@@ -48,6 +54,12 @@ project-scoped workspace.
    before/after quality evidence. Do not hide failures by changing thresholds.
 9. Export a nonempty `.hm` model, requested solver deck, quality summary, and
    a concise report with limitations.
+
+For tetra failures, export exact per-element values, cross-correlate active
+failure sets, classify boundary versus interior hotspots, and repair one
+checkpointed hotspot at a time. A hard zero-failure claim also requires an
+independent solver-deck reload and a separate CAD-adherence audit for moved
+boundary nodes.
 
 ## Acceptance Gates
 


### PR DESCRIPTION
## Summary

- Adds a reusable `hypermesh-evidence-meshing` skill integrated with the existing HyperWorks MCP.
- Covers measured partition planning, holes/washers, fillets and chamfers, spheres/flanges, mapped and swept blocks, and surface-first tetra meshing.
- Adds checkpointed hotspot remediation, exact quality evidence, independent reload checks, and CAD-adherence gates for hard zero-failure deliverables.
- Links the existing HyperMesh Subagent to the detailed skill and adds the skill to the English and Chinese indexes.

## Validation

- Skill structure validation passed.
- Public safety and Markdown-link audit: 0 errors, 0 warnings.
- No CAD, `.hm`, solver deck, generated mesh, logs, binaries, or workstation paths are included.

## Relationship to prior work

This builds on merged PR #13 by adding the detailed reusable Skill and advanced quality-remediation references rather than duplicating the original Subagent.