### PR TITLE
Add COMSOL permanent-magnet motor NVH evidence skill

### DIFF
--- a/MCP/COMSOL/README.md
+++ b/MCP/COMSOL/README.md
@@ -199,3 +199,10 @@ protocol behavior:
 
 Do not commit COMSOL binaries, license files, generated `.mph` models, exported
 solver results, local `.env`, or `comsol_runs/`.
+
+For a checkpointed permanent-magnet motor noise, vibration, and harshness
+workflow, use the repository
+[`comsol-motor-nvh-evidence`](../../Skill/comsol/comsol-motor-nvh-evidence/SKILL.md)
+skill together with this MCP. The skill adds model-contract, smoke-matrix,
+Campbell-data, and release-evidence gates without storing proprietary models or
+solver results.

--- a/MCP/COMSOL/README.zh-CN.md
+++ b/MCP/COMSOL/README.zh-CN.md
@@ -145,3 +145,8 @@ Python 测试不依赖 COMSOL，只验证环境探测和 bridge 协议：
 
 不要提交 COMSOL 二进制文件、许可证文件、生成的 `.mph` 模型、求解结果、本机
 `.env` 或 `comsol_runs/`。
+
+如需执行带检查点的永磁电机 NVH 工作流，请将本 MCP 与仓库中的
+[`comsol-motor-nvh-evidence`](../../Skill/comsol/comsol-motor-nvh-evidence/SKILL.md)
+Skill 配合使用。该 Skill 增加模型合同、缩减矩阵、Campbell 数据与发布证据门槛，
+且不会把专有模型或求解结果纳入仓库。

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This repository separates responsibilities:
 | [ovito-evidence-postprocessing](Skill/ovito/ovito-evidence-postprocessing) | Active | Evidence-first OVITO atomistic postprocessing workflow. | OVITO, visualization, atomistic |
 | [ansys-mechanical-evidence-structural](Skill/Ansys/ansys-mechanical-evidence-structural) | Active | Mechanical evidence and acceptance gates, complementary to the Workbench workflow skill. | Mechanical, ACT, PyMechanical, MAPDL |
 | [aedt-evidence-electromagnetics](Skill/Ansys/aedt-evidence-electromagnetics) | Active | Generic AEDT evidence workflow with Maxwell checks. | AEDT, Maxwell, HFSS, PyAEDT |
+| [comsol-motor-nvh-evidence](Skill/comsol/comsol-motor-nvh-evidence) | Active | Checkpointed permanent-magnet motor NVH workflow coupling rotating electromagnetics, structural modes, acoustics, and Campbell validation. | COMSOL, motor NVH, Maxwell force, modes, Campbell |
 | [calculix-fem](Skill/calculix/calculix-fem) | Active | Workflow for driving the CalculiX MCP: inspect a `.inp` deck, edit design variables in place, run ccx, read `.dat` results, export `result_mesh.json`. | CalculiX, FEM, ccx, .inp, linear static |
 | [calculix-sizing-optimization](Skill/calculix/calculix-sizing-optimization) | Active | Two-stage sizing optimization on a CalculiX shell/beam deck (LHS sweep + coordinate descent) to minimize mass s.t. stress/displacement bounds. | CalculiX, sizing optimization, mass reduction, LHS, coordinate descent |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,6 +87,7 @@ AI client
 | [ovito-evidence-postprocessing](Skill/ovito/ovito-evidence-postprocessing) | Active | 证据优先的 OVITO 原子尺度后处理工作流。 | OVITO, visualization, atomistic |
 | [ansys-mechanical-evidence-structural](Skill/Ansys/ansys-mechanical-evidence-structural) | Active | 与 Workbench 主工作流互补的 Mechanical 证据和验收门槛。 | Mechanical, ACT, PyMechanical, MAPDL |
 | [aedt-evidence-electromagnetics](Skill/Ansys/aedt-evidence-electromagnetics) | Active | 含 Maxwell 检查的泛用 AEDT 证据工作流。 | AEDT, Maxwell, HFSS, PyAEDT |
+| [comsol-motor-nvh-evidence](Skill/comsol/comsol-motor-nvh-evidence) | Active | 检查点式永磁电机 NVH 工作流，耦合旋转电磁、结构模态、声学与 Campbell 验证。 | COMSOL, 电机 NVH, Maxwell 力, 模态, Campbell |
 | [calculix-fem](Skill/calculix/calculix-fem) | Active | 驱动 CalculiX MCP 的工作流：检视 `.inp`、原位修改设计变量、运行 ccx、读取 `.dat` 结果、导出 `result_mesh.json`。 | CalculiX, FEM, ccx, .inp, 线性静力 |
 | [calculix-sizing-optimization](Skill/calculix/calculix-sizing-optimization) | Active | 在 CalculiX 壳/梁 deck 上跑两阶段尺寸优化（LHS 粗扫 + 坐标下降），在应力/位移约束下最小化质量。 | CalculiX, 尺寸优化, 减重, LHS, 坐标下降 |
 

--- a/Skill/comsol/README.md
+++ b/Skill/comsol/README.md
@@ -1,0 +1,8 @@
+# COMSOL Skills
+
+- [`comsol-motor-nvh-evidence`](comsol-motor-nvh-evidence): checkpointed,
+  evidence-first permanent-magnet motor NVH modeling, solving, export, and
+  Campbell validation through COMSOL Java API, batch, and the repository MCP.
+
+The skill contains no `.mph` model, commercial manual, license data, solver
+log, generated field result, or author-machine path.

--- a/Skill/comsol/comsol-motor-nvh-evidence/SKILL.md
+++ b/Skill/comsol/comsol-motor-nvh-evidence/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: comsol-motor-nvh-evidence
+description: Evidence-first COMSOL Java API and batch workflow for permanent-magnet motor NVH. Use when Codex must build, resume, solve, validate, or report a 2D motor model that couples rotating magnetic machinery, Maxwell-force harmonics, structural eigenmodes, pressure acoustics, acoustic-structure interaction, far-field SPL, or Campbell sweeps; also use when converting an existing motor NVH prompt or run into public-safe scripts, checkpoints, exports, and acceptance evidence.
+---
+
+# COMSOL Motor NVH Evidence
+
+Execute a checkpointed motor-NVH workflow and prove each completed stage with solver-native evidence. Treat reference models as read-only fact sources, never as the target model.
+
+## Required context
+
+1. Read `MCP/COMSOL/README.md` and inspect only the files needed for the selected COMSOL backend.
+2. Use the repository COMSOL MCP for installation detection, MPh session startup, model inspection, parameter changes, study execution, evaluation, export, and save-copy operations. Use `comsolcompile` plus COMSOL batch only when the independent Java API build requires capabilities not exposed by typed MCP tools.
+3. Read [references/model-contract.md](references/model-contract.md) before creating geometry, physics, studies, or result nodes.
+4. Read [references/evidence-gates.md](references/evidence-gates.md) before solving or claiming success.
+
+## Execution sequence
+
+1. Inspect the environment without writing to reference models.
+2. Create a new run directory. Use [scripts/New-ComsolMotorNvhRun.ps1](scripts/New-ComsolMotorNvhRun.ps1) when a project scaffold is needed.
+3. Extract source-backed facts once into `facts.json`; use that compact file in later stages.
+4. Create the target with `ModelUtil.create()` for the independent Java API route, or use the MCP MPh session route for an existing user-owned model. Parameterize geometry, selections, materials, physics, mesh, studies, and exports.
+5. Build without solving. Stop if environment, topology, selections, material tables, physics compilation, or mesh gates fail.
+6. Compile with `comsolcompile`; do not substitute ordinary `javac`.
+7. Solve structural modes and save a new checkpoint.
+8. Solve the time-periodic electromagnetic field and force harmonics; save a new checkpoint.
+9. Run the mandatory reduced NVH smoke matrix. Do not start the full sweep until every smoke value is finite and traceable.
+10. Run the full speed/harmonic sweep, in batches when memory is constrained.
+11. Postprocess from solved checkpoints. Fix result expressions or export nodes without rerunning physics unless solution evidence is invalid.
+12. Validate exported CSV data with [scripts/validate_nvh_exports.py](scripts/validate_nvh_exports.py), scan run evidence, and generate the report.
+
+For the MPh route, start with `comsol_detect_tool`,
+`comsol_mph_availability_tool`, `comsol_start_session_async_tool`, and
+`comsol_start_session_status_tool`. Continue with the session-scoped open,
+summary, parameter, solve, evaluate, export, and save tools. Detection alone is
+not license proof; require a real solver-native operation.
+
+## Checkpoint contract
+
+Use monotonic checkpoints such as:
+
+```text
+models/01_built.mph
+models/02_modes_solved.mph
+models/03_em_solved.mph
+models/04_smoke_solved.mph
+models/05_final_solved.mph
+```
+
+Resume only when the checkpoint, corresponding successful solver log, and validation record all exist. File presence alone is insufficient.
+
+## Modeling guardrails
+
+- Use named selections for physics assignments. Use numeric entity IDs only as topology diagnostics for the current build.
+- Preserve the verified finalization method, usually Form Assembly with identity pairs for the motor/acoustic partition. Do not switch to Form Union to silence a pairing problem.
+- Do not invent missing magnet, winding, B-H, support, boundary, or observation-point data.
+- Do not change materials, polarity, winding phase, force scale, damping, or acoustic pressure to match a reference curve.
+- Keep unsolved Campbell cells missing/null; never convert them to `0 dB`.
+- Do not describe scan-line, interpolation, or dashboard effects as physical deformation.
+- Do not claim a study solved unless the COMSOL exit code, log, checkpoint, and expected numerical exports agree.
+
+## Failure policy
+
+Use `PENDING`, `INSPECTED`, `CONFIGURED`, `BUILT`, `COMPILED`, `SOLVED`, `EXPORTED`, `VERIFIED`, `FAILED`, or `BLOCKED` for stages.
+
+Allow automatic repair only for paths, quoting, version-specific API names, missing output directories, result expressions, export-node compatibility, and machine-specific solver allocation. Never auto-repair the physical definition to improve agreement.
+
+Report final status only as `PASSED`, `PASSED_WITH_LIMITATIONS`, `FAILED`, or `BLOCKED`.
+
+## Public-safe output
+
+- Keep executable paths in environment variables or ignored private configuration.
+- Do not commit `.mph`, `.class`, solver logs, commercial manuals, source reference models, videos, or large generated datasets.
+- Remove usernames, attachment identifiers, workstation paths, license-server details, and temporary-directory names.
+- Commit only reusable scripts, relative-path examples, small synthetic/sample tables, and documentation.

--- a/Skill/comsol/comsol-motor-nvh-evidence/agents/openai.yaml
+++ b/Skill/comsol/comsol-motor-nvh-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "COMSOL PM Motor NVH"
+  short_description: "Build and verify PM motor NVH workflows"
+  default_prompt: "Use $comsol-motor-nvh-evidence to build, run, and audit a checkpointed COMSOL Java API motor NVH study."

--- a/Skill/comsol/comsol-motor-nvh-evidence/references/evidence-gates.md
+++ b/Skill/comsol/comsol-motor-nvh-evidence/references/evidence-gates.md
@@ -1,0 +1,134 @@
+# Motor NVH Evidence Gates
+
+## Contents
+
+- Gate A: environment
+- Gate B: geometry and selections
+- Gate C: materials and physics
+- Gate D: mesh
+- Gate E: structural modes
+- Gate F: electromagnetic source
+- Gate G: vibration and acoustics
+- Gate H: exports and report
+- Release privacy gate
+
+## Gate A: environment
+
+Require:
+
+- COMSOL executable or batch command resolved from explicit input, environment, or ignored private config;
+- `comsolcompile` resolved for Java API sources;
+- solver-native smoke run proving license checkout;
+- required physics interfaces available;
+- output and temporary directories writable;
+- adequate memory estimate recorded.
+
+Path discovery alone does not prove license availability.
+
+## Gate B: geometry and selections
+
+Require:
+
+- pole, magnet, slot, air-gap, support, housing, acoustic, and PML topology consistent with the intended motor;
+- finalization method and identity pairs explicitly recorded;
+- all required named selections nonempty;
+- no accidental modification of a read-only reference model;
+- geometry statistics and at least one overview export.
+
+Treat numeric entity IDs and reference topology counts as diagnostics, not portable selection definitions.
+
+## Gate C: materials and physics
+
+Require:
+
+- every domain assigned exactly the intended material role;
+- B-H tables have the expected row counts and units when nonlinear iron is used;
+- permanent-magnet recoil permeability and remanence are sourced;
+- winding phase sequence, reverse-current subsets, magnet polarity, force-calculation selection, fixed constraints, acoustic-structure boundary, PML, and exterior-field boundary are nonempty;
+- all expressions compile without undefined variables.
+
+## Gate D: mesh
+
+Require:
+
+- mesh build completes;
+- PML meshing method is appropriate for the acoustic formulation;
+- no inverted or zero-size elements;
+- minimum quality and element counts exported;
+- air gap, magnets, teeth, coupling boundaries, and PML receive intended controls.
+
+Stop before formal solves when Gates A-D fail.
+
+## Gate E: structural modes
+
+Require:
+
+- requested mode count returned;
+- modes are finite, positive, and ascending;
+- no unintended rigid-body near-zero mode;
+- mode shapes are physically interpretable;
+- key modes are stable under the chosen mesh check when report-grade validation is requested.
+
+Reference frequency error belongs to a separate audit and must not override a physically valid independent model.
+
+## Gate F: electromagnetic source
+
+Require:
+
+- complete periodic solution exists;
+- magnetic flux and force values contain no NaN or Inf;
+- alternating magnet polarity and winding phase sequence are verified;
+- force harmonics required by the NVH study are readable;
+- reuse across speeds is justified by recorded electromagnetic assumptions.
+
+## Gate G: vibration and acoustics
+
+Require smoke validation before full validation.
+
+Smoke requirements:
+
+- every requested speed/harmonic pair has a solver record;
+- displacement, acoustic pressure, coupling transfer, PML, and exterior-field evaluation are finite;
+- observation coordinates and units are recorded.
+
+Full-sweep requirements:
+
+- speed list and harmonic expression match the run request;
+- each Campbell row identifies speed, harmonic, frequency, and SPL;
+- missing/unsolved combinations remain null or absent, never `0 dB`;
+- no duplicate speed/harmonic pairs;
+- resonance peaks can be traced to excitation/modal proximity or another documented mechanism.
+
+## Gate H: exports and report
+
+Require:
+
+- source Java or batch input;
+- compilation and solver logs with exit codes;
+- checkpoint paths and loadability evidence;
+- geometry, mesh, modal, electromagnetic, acoustic, and Campbell exports;
+- machine-readable validation summary;
+- final report listing assumptions, failures, repairs, and unresolved limitations.
+
+Run:
+
+```powershell
+python Skill/comsol/comsol-motor-nvh-evidence/scripts/validate_nvh_exports.py `
+  --eigenfrequencies <run-dir>/exports/modes/eigenfrequencies.csv `
+  --campbell <run-dir>/exports/campbell/campbell_long.csv `
+  --output <run-dir>/validation/nvh_export_validation.json
+```
+
+Then inspect the run manifest, solver exit codes, checkpoints, exports, and the
+generated validation JSON before writing the final report.
+
+## Release privacy gate
+
+Before committing public files, require:
+
+- no drive-letter or home-directory paths;
+- no usernames, email addresses, attachment IDs, tokens, license-server strings, or machine names;
+- no `.mph`, `.class`, logs, videos, commercial manuals, or generated full-field datasets;
+- examples use placeholders, environment variables, and relative paths;
+- all Markdown links resolve;
+- repository public audit passes.

--- a/Skill/comsol/comsol-motor-nvh-evidence/references/model-contract.md
+++ b/Skill/comsol/comsol-motor-nvh-evidence/references/model-contract.md
@@ -1,0 +1,182 @@
+# PM Motor NVH Model Contract
+
+## Contents
+
+- Baseline scope
+- Parameter relations
+- Geometry and selections
+- Materials and physics
+- Mesh
+- Study sequence
+- Outputs
+- Reference-audit example
+
+## Baseline scope
+
+Use this contract as a reusable 2D surface-mounted permanent-magnet motor NVH baseline. Adapt dimensions and material data only from traceable user inputs, source files, or approved engineering assumptions.
+
+The demonstrated topology is a 10-pole/12-slot machine with an external acoustic domain and PML. It couples:
+
+```text
+rotating magnetic machinery
+-> Maxwell-force harmonics
+-> structural frequency response
+-> pressure acoustics
+-> exterior sound-pressure level
+```
+
+## Parameter relations
+
+Define all quantities as COMSOL parameters with units.
+
+| Symbol | Meaning | Demonstrated value/relation |
+|---|---|---|
+| `Np` | pole count | `10` |
+| `Ns` | slot count | `12` |
+| `n_shaft` | shaft speed | parameter in `rpm` |
+| `n_cog` | cogging-period count | `Ns/gcd(Np,Ns)*2` |
+| `Nframes` | electromagnetic phase frames | `n_cog*6` |
+| `Ipk` | phase-current peak | source-backed input |
+| `init_ang` | initial electrical/mechanical alignment | source-backed input |
+| `L` | axial stack length used by the 2D model | source-backed input |
+| `freq_min` | lower Campbell control frequency | study input |
+
+For a numeric speed in rpm:
+
+```text
+electrical_frequency_hz = n_shaft_rpm * Np / 120
+excitation_frequency_hz = harmonic * electrical_frequency_hz
+mechanical_order = harmonic * Np / 2
+```
+
+With `Np=10`, the electrical frequency is `rpm/12`, and harmonic `h=4` is mechanical order 20.
+
+## Geometry and selections
+
+Prefer COMSOL Application Library parametric rotor and stator geometry parts when they are available and licensed. Resolve them relative to `COMSOL_ROOT`; never commit an author-machine path.
+
+Build the target from a blank model. A typical order is:
+
+```text
+parameters
+rotor part instance
+stator part instance
+housing and supports
+external acoustic domain and PML
+boolean features
+named selections
+assembly finalization and identity pairs
+```
+
+Create stable named selections for at least:
+
+- rotor magnets and alternating north/south subsets;
+- stator iron and winding domains;
+- phase A/B/C windings and reverse-current subsets;
+- electromagnetic air/rotating domains;
+- structural domains and fixed boundaries;
+- acoustic and PML domains;
+- acoustic-structure and exterior-field boundaries.
+
+Require every selection used by a material, physics feature, mesh feature, coupling, or export to be nonempty after geometry finalization.
+
+Topology counts from a reference model may diagnose a build, but they are not universal hard gates. Do not delete arbitrary domains merely to match counts.
+
+## Materials and physics
+
+Use source-backed material properties. A demonstrated configuration used:
+
+- air for the acoustic/electromagnetic surroundings;
+- structural steel for housing/support domains;
+- soft iron with ordinary and effective B-H interpolation tables;
+- N42 NdFeB with source-backed recoil permeability and remanence.
+
+Create and audit these interfaces:
+
+| Tag | Role |
+|---|---|
+| `mmtp` | Magnetic Machinery, Rotating, Time Periodic |
+| `solid` | Solid Mechanics |
+| `acpr` | Pressure Acoustics, Frequency Domain |
+| `asb1` | Acoustic-Structure Boundary |
+
+The electromagnetic definition must explicitly record magnet polarity, three-phase winding sequence, reverse-current domains, force-calculation selection, and whether speed-dependent induced currents are neglected. Reusing one electromagnetic solution across speeds is allowed only when those assumptions make force amplitude and phase speed-independent.
+
+Do not introduce damping merely to suppress an undamped resonance. If damping is required by the real design, treat it as a separate, sourced model revision.
+
+## Mesh
+
+Use a user-controlled mesh. Include:
+
+- resolved air-gap and magnet/tooth regions;
+- mapped elements through PML where required by the acoustic formulation;
+- boundary-layer or near-boundary refinement where source transfer requires it;
+- exported element count, minimum quality, invalid-element count, and feature inventory.
+
+Run a refined-mesh check only after the baseline passes. Recompute any physics affected by mesh changes.
+
+## Study sequence
+
+### Study 1: structural eigenmodes
+
+- Solve `solid` only.
+- Request enough modes to cover the excitation band; the demonstrated case requested seven.
+- Require positive, ascending modes and no unintended near-zero rigid-body mode.
+- Export the frequencies and representative mode shapes.
+
+### Study 2: time-periodic electromagnetics
+
+- Solve `mmtp` at the source-backed operating condition.
+- Retain a complete phase cycle and force harmonics needed by Study 3.
+- Require alternating magnet polarity, correct winding phase, finite fields, and finite force coefficients.
+
+### Study 3 smoke: vibration and acoustics
+
+Run a small matrix before the full sweep. A demonstrated smoke set used:
+
+```text
+speeds_rpm = 3000, 7000, 12000
+harmonics = 2, 4, 6
+```
+
+Solve structural frequency response, pressure acoustics, and acoustic-structure coupling. Read the electromagnetic source from Study 2 without silently resolving or replacing it.
+
+### Study 3 full: Campbell sweep
+
+A demonstrated 17-speed grid was:
+
+```text
+900, 1200, 1500, 1800, 2100, 2400, 2700, 3000,
+4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000 rpm
+```
+
+For each speed, generate the requested harmonic frequencies from the parameter expression. Preserve missing low-frequency cells as missing data. When memory is limited, split speeds into batches, export scalars immediately, and retain full fields only for key cases.
+
+## Outputs
+
+Export at minimum:
+
+```text
+geometry overview and topology statistics
+mesh overview and quality statistics
+eigenfrequency CSV and mode-shape images
+magnetic flux-density result
+force-harmonic CSV
+far-field directivity CSV for a key case
+Campbell long-form CSV and matrix CSV
+solver logs, evidence summary, and final report
+```
+
+Probe result expressions against the solved dataset before creating bulk exports. If an image export fails but the underlying numeric solution is valid, repair only the postprocessing path and document the limitation.
+
+## Reference-audit example
+
+The following values describe one completed 10-pole/12-slot baseline and are useful only to test a reproduction of that same definition:
+
+```text
+modes_hz = 929.448, 2324.427, 4507.714, 6888.555,
+           9632.170, 10343.030, 12387.507
+key_case = 7000 rpm, h=4, 2333.333 Hz, approximately 104.84 dB
+```
+
+Keep this comparison under `REFERENCE_AUDIT`. A different motor can pass the physical and numerical gates while producing different values.

--- a/Skill/comsol/comsol-motor-nvh-evidence/scripts/New-ComsolMotorNvhRun.ps1
+++ b/Skill/comsol/comsol-motor-nvh-evidence/scripts/New-ComsolMotorNvhRun.ps1
@@ -1,0 +1,94 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$RunRoot,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[a-z0-9][a-z0-9-]{1,62}$')]
+  [string]$CaseName,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Objective,
+
+  [ValidateSet('BUILD_MODE', 'SMOKE_MODE', 'FULL_MODE', 'LOW_MEMORY_MODE')]
+  [string]$Mode = 'SMOKE_MODE',
+
+  [ValidateRange(1, 256)]
+  [int]$BatchCores = 1,
+
+  [switch]$ForceManifest
+)
+
+$ErrorActionPreference = 'Stop'
+$resolvedRunRoot = [System.IO.Path]::GetFullPath($RunRoot)
+$runDirectory = Join-Path $resolvedRunRoot $CaseName
+$manifestPath = Join-Path $runDirectory 'run-request.json'
+
+if ((Test-Path -LiteralPath $manifestPath) -and -not $ForceManifest) {
+  throw "Run manifest already exists: $manifestPath. Use -ForceManifest only when replacement is intended."
+}
+
+$directories = @(
+  $runDirectory,
+  (Join-Path $runDirectory 'config'),
+  (Join-Path $runDirectory 'scripts'),
+  (Join-Path $runDirectory 'inputs'),
+  (Join-Path $runDirectory 'models'),
+  (Join-Path $runDirectory 'logs'),
+  (Join-Path $runDirectory 'exports'),
+  (Join-Path $runDirectory 'exports\geometry'),
+  (Join-Path $runDirectory 'exports\mesh'),
+  (Join-Path $runDirectory 'exports\modes'),
+  (Join-Path $runDirectory 'exports\electromagnetic'),
+  (Join-Path $runDirectory 'exports\vibroacoustic'),
+  (Join-Path $runDirectory 'exports\campbell'),
+  (Join-Path $runDirectory 'validation')
+)
+
+if ($PSCmdlet.ShouldProcess($runDirectory, 'Create COMSOL motor NVH run scaffold')) {
+  foreach ($directory in $directories) {
+    New-Item -ItemType Directory -Force -Path $directory | Out-Null
+  }
+
+  $manifest = [ordered]@{
+    schema_version = 1
+    solver = 'comsol'
+    case_name = $CaseName
+    objective = $Objective
+    created_utc = [DateTime]::UtcNow.ToString('o')
+    mode = $Mode
+    batch_cores = $BatchCores
+    status = 'PENDING'
+    toolchain = [ordered]@{
+      root = '${COMSOL_ROOT}'
+      batch = '${COMSOL_BATCH}'
+      compile = '${COMSOL_COMPILE}'
+      java = '${COMSOL_JAVA}'
+      temp = '${COMSOL_TMPDIR}'
+    }
+    checkpoints = @(
+      'models/01_built.mph'
+      'models/02_modes_solved.mph'
+      'models/03_em_solved.mph'
+      'models/04_smoke_solved.mph'
+      'models/05_final_solved.mph'
+    )
+    evidence = [ordered]@{
+      compile_log = 'logs/comsol_compile.log'
+      build_log = 'logs/build.log'
+      study1_log = 'logs/study1_modes.log'
+      study2_log = 'logs/study2_electromagnetic.log'
+      smoke_log = 'logs/study3_smoke.log'
+      full_log = 'logs/study3_full.log'
+      report = 'validation/final_acceptance.md'
+    }
+  }
+
+  $manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+}
+
+[pscustomobject]@{
+  status = 'created'
+  run_directory = $runDirectory
+  manifest = $manifestPath
+}

--- a/Skill/comsol/comsol-motor-nvh-evidence/scripts/validate_nvh_exports.py
+++ b/Skill/comsol/comsol-motor-nvh-evidence/scripts/validate_nvh_exports.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def require_columns(rows: list[dict[str, str]], required: set[str], label: str) -> None:
+    if not rows:
+        raise ValueError(f"{label} contains no data rows")
+    missing = required.difference(rows[0])
+    if missing:
+        raise ValueError(f"{label} is missing columns: {sorted(missing)}")
+
+
+def finite_float(value: str, label: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"{label} is not finite: {value}")
+    return parsed
+
+
+def validate(eigen_path: Path, campbell_path: Path, pole_count: int) -> dict[str, object]:
+    eigen_rows = read_rows(eigen_path)
+    campbell_rows = read_rows(campbell_path)
+    require_columns(eigen_rows, {"mode", "frequency_hz"}, "eigenfrequency CSV")
+    require_columns(campbell_rows, {"rpm", "harmonic", "frequency_hz", "spl_db"}, "Campbell CSV")
+
+    modes = [
+        {
+            "mode": int(row["mode"]),
+            "frequency_hz": finite_float(row["frequency_hz"], "mode frequency"),
+        }
+        for row in eigen_rows
+    ]
+    mode_frequencies = [row["frequency_hz"] for row in modes]
+    if any(value <= 0 for value in mode_frequencies):
+        raise ValueError("all eigenfrequencies must be positive")
+    if mode_frequencies != sorted(mode_frequencies):
+        raise ValueError("eigenfrequencies must be ascending")
+
+    points: list[dict[str, float | int]] = []
+    keys: set[tuple[float, int]] = set()
+    max_frequency_error = 0.0
+    for row in campbell_rows:
+        rpm = finite_float(row["rpm"], "rpm")
+        harmonic = int(row["harmonic"])
+        frequency = finite_float(row["frequency_hz"], "excitation frequency")
+        spl = finite_float(row["spl_db"], "SPL")
+        key = (rpm, harmonic)
+        if key in keys:
+            raise ValueError(f"duplicate Campbell point: rpm={rpm}, harmonic={harmonic}")
+        keys.add(key)
+        expected_frequency = rpm * pole_count * harmonic / 120.0
+        frequency_error = abs(frequency - expected_frequency)
+        max_frequency_error = max(max_frequency_error, frequency_error)
+        nearest_index = min(range(len(mode_frequencies)), key=lambda idx: abs(mode_frequencies[idx] - frequency))
+        points.append(
+            {
+                "rpm": rpm,
+                "harmonic": harmonic,
+                "frequency_hz": frequency,
+                "spl_db": spl,
+                "nearest_mode": modes[nearest_index]["mode"],
+                "modal_gap_hz": abs(mode_frequencies[nearest_index] - frequency),
+            }
+        )
+
+    if max_frequency_error > 1e-6:
+        raise ValueError(f"Campbell frequency relation failed; maximum error is {max_frequency_error:.9g} Hz")
+
+    closest = sorted(points, key=lambda point: point["modal_gap_hz"])[:10]
+    peak = max(points, key=lambda point: point["spl_db"])
+    speeds = sorted({point["rpm"] for point in points})
+    harmonics = sorted({point["harmonic"] for point in points})
+
+    return {
+        "status": "PASS",
+        "pole_count": pole_count,
+        "mode_count": len(modes),
+        "campbell_point_count": len(points),
+        "speed_count": len(speeds),
+        "speeds_rpm": speeds,
+        "harmonics": harmonics,
+        "maximum_frequency_relation_error_hz": max_frequency_error,
+        "peak_spl_point": peak,
+        "closest_modal_intersections": closest,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate COMSOL PM-motor NVH mode and Campbell CSV exports.")
+    parser.add_argument("--eigenfrequencies", type=Path, required=True)
+    parser.add_argument("--campbell", type=Path, required=True)
+    parser.add_argument("--pole-count", type=int, default=10)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    result = validate(args.eigenfrequencies, args.campbell, args.pole_count)
+    text = json.dumps(result, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a checkpointed `comsol-motor-nvh-evidence` skill for rotating electromagnetics, Maxwell-force harmonics, structural modes, pressure acoustics, far-field SPL, and Campbell sweeps.
- Adds model-contract and evidence-gate references, a PowerShell run scaffold, and a deterministic eigenfrequency/Campbell CSV validator.
- Integrates the skill with the existing COMSOL MPh/Java bridge MCP documentation and the English and Chinese skill indexes.
- Keeps reference models read-only and excludes `.mph` files, commercial manuals, license information, solver logs, videos, generated field results, and workstation paths.

## Validation

- Skill structure validation passed.
- Public safety and Markdown-link audit: 0 errors, 0 warnings.
- Existing COMSOL MCP unit tests: 14/14 passed.
- CSV validator exercised against a completed 10-pole/12-slot run: 7 modes, 160 Campbell points, 17 speeds, maximum frequency-relation error about `1.82e-12 Hz`; peak point at 7000 rpm / harmonic 4 / 104.84 dB.