### PR TITLE
fix: pin FEP MCP SDK v1 and add CI

### DIFF
--- a/.github/workflows/fep-agent-hub-test.yml
+++ b/.github/workflows/fep-agent-hub-test.yml
@@ -1,0 +1,29 @@
+name: FEP Agent Hub test
+
+on:
+  push:
+    paths:
+      - "MCP/FEP-Agent-Hub/**"
+      - ".github/workflows/fep-agent-hub-test.yml"
+  pull_request:
+    paths:
+      - "MCP/FEP-Agent-Hub/**"
+      - ".github/workflows/fep-agent-hub-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: MCP/FEP-Agent-Hub
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -r requirements.txt
+      - run: python -m pip install -e packages/open-cae-core -e mcp/freecad -e mcp/elmer -e mcp/paraview
+      - run: python -m pytest -q

--- a/MCP/FEP-Agent-Hub/mcp/elmer/pyproject.toml
+++ b/MCP/FEP-Agent-Hub/mcp/elmer/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "open-cae-elmer-mcp"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["mcp>=1.0", "meshio>=5.0", "numpy>=1.26", "open-cae-core==0.1.0"]
+dependencies = ["mcp>=1.27,<2", "meshio>=5.0", "numpy>=1.26", "open-cae-core==0.1.0"]
 
 [project.scripts]
 open-cae-elmer-mcp = "elmer_mcp.server:main"

--- a/MCP/FEP-Agent-Hub/mcp/freecad/pyproject.toml
+++ b/MCP/FEP-Agent-Hub/mcp/freecad/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "open-cae-freecad-mcp"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["mcp>=1.0", "open-cae-core==0.1.0"]
+dependencies = ["mcp>=1.27,<2", "open-cae-core==0.1.0"]
 
 [project.scripts]
 open-cae-freecad-mcp = "freecad_mcp.server:main"

--- a/MCP/FEP-Agent-Hub/mcp/paraview/pyproject.toml
+++ b/MCP/FEP-Agent-Hub/mcp/paraview/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "open-cae-paraview-mcp"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["mcp>=1.0", "open-cae-core==0.1.0"]
+dependencies = ["mcp>=1.27,<2", "open-cae-core==0.1.0"]
 
 [project.scripts]
 open-cae-paraview-mcp = "paraview_mcp.server:main"

--- a/MCP/FEP-Agent-Hub/pyproject.toml
+++ b/MCP/FEP-Agent-Hub/pyproject.toml
@@ -5,7 +5,7 @@ description = "Evidence-first FreeCAD, Elmer FEM, and ParaView MCP agent stack."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "mcp>=1.0",
+  "mcp>=1.27,<2",
   "pydantic>=2.0",
 ]
 

--- a/MCP/FEP-Agent-Hub/requirements.txt
+++ b/MCP/FEP-Agent-Hub/requirements.txt
@@ -1,4 +1,4 @@
-mcp>=1.0
+mcp>=1.27,<2
 meshio>=5.0
 numpy>=1.26
 opencv-python-headless>=4.10


### PR DESCRIPTION
## Summary

- constrain the FEP integration to `mcp>=1.27,<2`, matching its current `mcp.server.fastmcp.FastMCP` implementation
- apply the same constraint to the root package and all three MCP server packages
- add a path-scoped Windows GitHub Actions workflow for `MCP/FEP-Agent-Hub`
- use Node 24-compatible `actions/checkout@v5` and `actions/setup-python@v6`

## Root cause

An unconstrained `mcp>=1.0` install now resolves to MCP Python SDK 2.x. SDK v2 removed `mcp.server.fastmcp`, so pytest failed during collection before any FEP tests could run.

## Validation

- clean Python 3.12 environment resolved `mcp==1.29.0`
- `from mcp.server.fastmcp import FastMCP`: PASS
- Python tests: 17 passed, 1 native opt-in test skipped
- standalone repository GitHub Actions: PASS
- FEP protocol inventory: FreeCAD 15, Elmer 17, ParaView 17
- native heat smoke and full MCP contract matrix: PASS

The workflow is limited to FEP paths and does not affect unrelated integrations.