### PR TITLE
Fix HyperWorks 2025 extension compatibility

### DIFF
--- a/MCP/HyperWorks/hyperworks_extension/extension.xml
+++ b/MCP/HyperWorks/hyperworks_extension/extension.xml
@@ -1,7 +1,7 @@
 <section name="Extension">
     <entry name="name" value="HyperWorks MCP Bridge" />
     <entry name="displayName" value="HyperWorks MCP Bridge" />
-    <entry name="minProductVersion" value="2026" />
+    <entry name="minProductVersion" value="2025" />
     <entry name="version" value="0.9.1" />
     <entry name="author" value="CAE-Agent-Hub" />
     <entry name="description" value="Authenticated localhost bridge for controlled HyperMesh preprocessing and HyperView result postprocessing." />

--- a/MCP/HyperWorks/hyperworks_extension/hyperworks_mcp_extension/bridge.py
+++ b/MCP/HyperWorks/hyperworks_extension/hyperworks_mcp_extension/bridge.py
@@ -97,7 +97,10 @@ class BridgeRuntime:
     def start(self) -> None:
         if self.server is not None:
             return
-        from PyQt6.QtCore import QTimer
+        try:
+            from PyQt6.QtCore import QTimer
+        except ImportError:
+            from PyQt5.QtCore import QTimer
 
         self.server = _BridgeTCPServer((self.host, self.port), self)
         self.server_thread = threading.Thread(


### PR DESCRIPTION
## 修改内容

- 将 HyperWorks MCP Bridge 的 minProductVersion 从 2026 调整为 2025。
- Extension 启动时优先导入 PyQt6；当 HyperWorks 内嵌环境未提供 PyQt6 时，回退到 PyQt5。

## 背景

HyperWorks 2025.0 内嵌 Python 3.8 和 PyQt5，不提供 PyQt6。原实现硬编码导入 PyQt6，导致 Extension Manager 在执行初始化脚本时失败。加入 PyQt5 回退后，已在本机 HyperWorks 2025 上验证实时 MCP 桥接连接成功，并完成 MCP 读写操作。

## 验证

- HyperWorks 2025.0 实机：Extension 加载成功，MCP 实时桥接读写成功。
- HyperWorks 2025 自带 Python 3.8：全部 Extension Python 文件编译通过。
- extension.xml：XML 解析通过。
- HyperWorks MCP pytest：41 passed。

Closes #24