### PR TITLE
Release ANSYS Workbench MCP 0.2.1

### DIFF
--- a/MCP/Ansys/Workbench MCP/README.md
+++ b/MCP/Ansys/Workbench MCP/README.md
@@ -19,7 +19,7 @@ From this folder:
 ```powershell
 py -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
-.\.venv\Scripts\python.exe -m pip install -e .[mechanical]
+.\.venv\Scripts\python.exe -m pip install -e .[workbench]
 ```
 
 Copy `.env.example` to `.env` and set your local ANSYS paths.
@@ -50,7 +50,7 @@ Please configure Codex MCP with a stdio server named `ansys-workbench`:
 If the virtual environment does not exist, create it and install the project with:
 py -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
-.\.venv\Scripts\python.exe -m pip install -e .[mechanical]
+.\.venv\Scripts\python.exe -m pip install -e .[workbench]
 
 After configuring the server, verify it by listing MCP tools and then run `workbench_detect_tool`.
 ```
@@ -73,7 +73,7 @@ Use a stdio MCP server named `ansys-workbench`:
   - WORKBENCH_MCP_QUEUE_ROOT=<repo>\workbench_queue
   - WORKBENCH_MCP_PORT=9885
 
-If dependencies are missing, create `.venv` and run `pip install -e .[mechanical]`.
+If dependencies are missing, create `.venv` and run `pip install -e .[workbench]`.
 Then restart Claude Code and confirm the Workbench MCP tools are available.
 ```
 
@@ -122,7 +122,7 @@ Add a stdio MCP server named `ansys-workbench` using:
   - WORKBENCH_MCP_HOST=127.0.0.1
   - WORKBENCH_MCP_PORT=9885
 
-If `.venv` is missing, create it and install dependencies with `pip install -e .[mechanical]`.
+If `.venv` is missing, create it and install dependencies with `pip install -e .[workbench]`.
 After saving the MCP settings, reload Cursor and run a tool discovery check.
 ```
 
@@ -177,7 +177,7 @@ The plugin also auto-starts the queue timer and socket timer by default. Set `WO
 
 ## MCP Tools
 
-The server exposes tools for:
+Version 0.2.0 exposes 45 tools across the original bridge, the high-level Workbench session layer, and the Mechanical structural workflows:
 
 - detecting Workbench and PyMechanical
 - launching Workbench journals
@@ -185,6 +185,24 @@ The server exposes tools for:
 - reading job logs and status
 - submitting queue requests to Mechanical
 - executing Python in the currently open Mechanical session through the queue or socket timer bridge
+
+### High-level Workbench session tools
+
+- `workbench_session_status_tool`: process and managed-session inventory.
+- `workbench_bootstrap_current_tool`: identity-gated bootstrap of the one current Workbench through the live bridge.
+- `workbench_attach_current_tool`: attach to a known Workbench `StartServer` endpoint.
+- `workbench_launch_managed_tool`: launch only when no Workbench process already exists.
+- `workbench_project_inventory_tool`: exact project and internal-system inventory.
+- `workbench_project_open_tool`: guarded `.wbpj` open in an empty managed session.
+- `workbench_project_save_as_tool`: non-overwriting save-as by default.
+- `workbench_model_open_tool`: open/connect one exact Mechanical Model session.
+- `workbench_model_state_tool`: verify project, system, bodies, analyses, and types.
+- `workbench_model_execute_python_tool`: execute Mechanical Python after the identity gate passes.
+- `workbench_session_disconnect_tool`: close MCP client channels without terminating Workbench or Mechanical.
+
+MCP tool discovery is performed when the stdio server starts. After upgrading,
+restart or reload the MCP server process; an already running process keeps its
+previous tool registry.
 
 ### Rotating-static and prestressed-modal tools
 
@@ -247,6 +265,29 @@ Run the offline tests with:
 $env:PYTHONDONTWRITEBYTECODE='1'
 python -m unittest discover -s tests -v
 ```
+
+## Fusion STEP to beam intake templates
+
+The repository includes a guarded V252 intake kit for Fusion 360 thin-wall solids that will later become SpaceClaim/Mechanical beam bodies:
+
+- `examples/workbench_import_step_v252.wbjn.template`: Workbench STEP intake journal.
+- `tools/prepare_beam_import_smoke.py`: validates the source file, refuses unapproved overwrite, and renders the journal plus a `NOT_RUN` request record.
+- `examples/spaceclaim_thinwall_step_to_beam_v252.py.template`: recorder-first SpaceClaim conversion skeleton. It intentionally stops at `RECORDER_REQUIRED` until the active V252 selection/extraction commands are captured.
+- `examples/mechanical_line_body_inspection_v252.py`: read-only Mechanical Line Body inventory for the main-context queue.
+- `examples/beam_import_smoke_contract.schema.json` and `tools/validate_beam_import_contract.py`: common evidence contract and static validator.
+
+Prepare, but do not run, an import journal:
+
+```powershell
+.\.venv\Scripts\python.exe tools\prepare_beam_import_smoke.py `
+  --step "C:\absolute\model.step" `
+  --project "C:\absolute\output\model.wbpj" `
+  --output-dir "C:\absolute\output\prepared" `
+  --units mm `
+  --open-spaceclaim
+```
+
+Then submit the rendered `.wbjn` through `workbench_run_journal_tool` with `batch=false` when a graphical SpaceClaim session is required. Workbench journal completion is not proof that beam idealization or Mechanical Line Body intake passed; those gates require their own observed reports.
 
 ## Notes
 

--- a/MCP/Ansys/Workbench MCP/README.md
+++ b/MCP/Ansys/Workbench MCP/README.md
@@ -177,7 +177,7 @@ The plugin also auto-starts the queue timer and socket timer by default. Set `WO
 
 ## MCP Tools
 
-Version 0.2.0 exposes 45 tools across the original bridge, the high-level Workbench session layer, and the Mechanical structural workflows:
+Version 0.2.1 exposes 45 tools across the original bridge, the high-level Workbench session layer, and the Mechanical structural workflows:
 
 - detecting Workbench and PyMechanical
 - launching Workbench journals

--- a/MCP/Ansys/Workbench MCP/README.zh-CN.md
+++ b/MCP/Ansys/Workbench MCP/README.zh-CN.md
@@ -177,7 +177,7 @@ WORKBENCH_MCP_PORT=9885
 
 ## MCP 工具
 
-0.2.0 版本共暴露 45 个工具，覆盖原有桥接、高层 Workbench 会话层和 Mechanical 结构分析工作流：
+0.2.1 版本共暴露 45 个工具，覆盖原有桥接、高层 Workbench 会话层和 Mechanical 结构分析工作流：
 
 - 检测 Workbench 和 PyMechanical
 - 启动 Workbench journal

--- a/MCP/Ansys/Workbench MCP/README.zh-CN.md
+++ b/MCP/Ansys/Workbench MCP/README.zh-CN.md
@@ -19,7 +19,7 @@
 ```powershell
 py -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
-.\.venv\Scripts\python.exe -m pip install -e .[mechanical]
+.\.venv\Scripts\python.exe -m pip install -e .[workbench]
 ```
 
 复制 `.env.example` 为 `.env`，然后填入你本机的 ANSYS 路径。
@@ -50,7 +50,7 @@ py -m venv .venv
 如果虚拟环境还不存在，请先创建并安装依赖：
 py -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
-.\.venv\Scripts\python.exe -m pip install -e .[mechanical]
+.\.venv\Scripts\python.exe -m pip install -e .[workbench]
 
 配置完成后，请通过列出 MCP tools 来验证，并运行 `workbench_detect_tool`。
 ```
@@ -73,7 +73,7 @@ py -m venv .venv
   - WORKBENCH_MCP_QUEUE_ROOT=<repo>\workbench_queue
   - WORKBENCH_MCP_PORT=9885
 
-如果依赖缺失，请创建 `.venv` 并运行 `pip install -e .[mechanical]`。
+如果依赖缺失，请创建 `.venv` 并运行 `pip install -e .[workbench]`。
 然后重启 Claude Code，确认 Workbench MCP tools 已可用。
 ```
 
@@ -122,7 +122,7 @@ py -m venv .venv
   - WORKBENCH_MCP_HOST=127.0.0.1
   - WORKBENCH_MCP_PORT=9885
 
-如果 `.venv` 不存在，请创建虚拟环境并安装依赖：`pip install -e .[mechanical]`。
+如果 `.venv` 不存在，请创建虚拟环境并安装依赖：`pip install -e .[workbench]`。
 保存 MCP 设置后，重新加载 Cursor，并执行一次 tool discovery 检查。
 ```
 
@@ -177,7 +177,7 @@ WORKBENCH_MCP_PORT=9885
 
 ## MCP 工具
 
-服务器提供以下工具：
+0.2.0 版本共暴露 45 个工具，覆盖原有桥接、高层 Workbench 会话层和 Mechanical 结构分析工作流：
 
 - 检测 Workbench 和 PyMechanical
 - 启动 Workbench journal
@@ -185,6 +185,23 @@ WORKBENCH_MCP_PORT=9885
 - 读取作业日志和状态
 - 向 Mechanical 提交队列请求
 - 通过队列或 socket timer 在当前打开的 Mechanical 会话中执行 Python
+
+### 高层 Workbench 会话工具
+
+- `workbench_session_status_tool`：进程和托管会话盘点。
+- `workbench_bootstrap_current_tool`：通过实时桥对唯一现有 Workbench 做身份门控启动/复用。
+- `workbench_attach_current_tool`：连接已知的 Workbench `StartServer` 端点。
+- `workbench_launch_managed_tool`：仅在没有现有 Workbench 进程时启动实例。
+- `workbench_project_inventory_tool`：读取精确工程和内部 System 名称。
+- `workbench_project_open_tool`：只在空托管会话中受保护地打开 `.wbpj`。
+- `workbench_project_save_as_tool`：默认禁止覆盖的另存为。
+- `workbench_model_open_tool`：打开并连接指定 System 的 Mechanical Model。
+- `workbench_model_state_tool`：核验工程、System、实体、分析及其类型。
+- `workbench_model_execute_python_tool`：仅在身份门通过后执行 Mechanical Python。
+- `workbench_session_disconnect_tool`：只关闭 MCP 客户端通道，不终止 Workbench 或 Mechanical。
+
+MCP 工具发现发生在 stdio server 启动时。升级后必须重载或重启 MCP server
+进程；已经运行的进程会继续保留旧工具注册表。
 
 ### 旋转静力与预应力模态工具
 
@@ -247,6 +264,29 @@ mechanical_readiness_tool
 $env:PYTHONDONTWRITEBYTECODE='1'
 python -m unittest discover -s tests -v
 ```
+
+## Fusion STEP 到梁模型的导入模板
+
+仓库现包含一套受保护的 V252 导入配套，用于把 Fusion 360 薄壁实体先导入 Workbench，后续再在 SpaceClaim/Mechanical 中转成梁体：
+
+- `examples/workbench_import_step_v252.wbjn.template`：Workbench STEP 导入 Journal。
+- `tools/prepare_beam_import_smoke.py`：检查源文件、拒绝未经授权的覆盖，并生成 Journal 和标记为 `NOT_RUN` 的请求记录。
+- `examples/spaceclaim_thinwall_step_to_beam_v252.py.template`：以 Script Recorder 为准的 SpaceClaim 转换骨架。在当前 V252 的选择/提取命令尚未录制前，会在 `RECORDER_REQUIRED` 主动停止。
+- `examples/mechanical_line_body_inspection_v252.py`：通过主线程队列执行的 Mechanical Line Body 只读盘点脚本。
+- `examples/beam_import_smoke_contract.schema.json` 与 `tools/validate_beam_import_contract.py`：统一证据契约和静态校验器。
+
+只准备、不运行导入 Journal：
+
+```powershell
+.\.venv\Scripts\python.exe tools\prepare_beam_import_smoke.py `
+  --step "C:\绝对路径\model.step" `
+  --project "C:\绝对路径\output\model.wbpj" `
+  --output-dir "C:\绝对路径\output\prepared" `
+  --units mm `
+  --open-spaceclaim
+```
+
+需要图形化 SpaceClaim 时，再通过 `workbench_run_journal_tool` 以 `batch=false` 提交生成的 `.wbjn`。Journal 执行完成不代表梁理想化或 Mechanical Line Body 导入通过；每个阶段必须有独立的实际观测报告。
 
 ## 说明
 

--- a/MCP/Ansys/Workbench MCP/examples/__init__.py
+++ b/MCP/Ansys/Workbench MCP/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged examples and guarded Workbench intake templates."""

--- a/MCP/Ansys/Workbench MCP/examples/beam_import_smoke_contract.schema.json
+++ b/MCP/Ansys/Workbench MCP/examples/beam_import_smoke_contract.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://local.invalid/ansys/beam-import-smoke-contract.schema.json",
+  "title": "Fusion STEP to ANSYS beam import smoke result",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "workflow",
+    "phase",
+    "status",
+    "ok",
+    "source_step",
+    "units",
+    "gates",
+    "warnings",
+    "errors",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "workflow": {"const": "fusion_step_to_beam_smoke"},
+    "phase": {
+      "enum": ["PREPARED", "WORKBENCH_STEP_IMPORT", "SPACECLAIM_BEAM_IDEALIZATION", "MECHANICAL_LINE_BODY_IMPORT"]
+    },
+    "status": {"enum": ["NOT_RUN", "BLOCKED", "FAIL", "PASS"]},
+    "ok": {"type": "boolean"},
+    "source_step": {"type": "string", "minLength": 1},
+    "project_path": {"type": ["string", "null"]},
+    "units": {"enum": ["mm", "m", "in"]},
+    "gates": {
+      "type": "object",
+      "required": ["step_file_check", "workbench_step_import", "spaceclaim_beam_idealization", "mechanical_line_body_import"],
+      "properties": {
+        "step_file_check": {"type": ["boolean", "null"]},
+        "workbench_step_import": {"type": ["boolean", "null"]},
+        "spaceclaim_beam_idealization": {"type": ["boolean", "null"]},
+        "mechanical_line_body_import": {"type": ["boolean", "null"]}
+      },
+      "additionalProperties": false
+    },
+    "members": {"type": "array", "items": {"type": "object"}},
+    "counts": {"type": "object"},
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "errors": {"type": "array", "items": {"type": "string"}},
+    "evidence": {"type": "object"}
+  },
+  "additionalProperties": true
+}

--- a/MCP/Ansys/Workbench MCP/examples/mechanical_line_body_inspection_v252.py
+++ b/MCP/Ansys/Workbench MCP/examples/mechanical_line_body_inspection_v252.py
@@ -1,0 +1,97 @@
+import json
+import traceback
+
+from Ansys.Mechanical.DataModel.Enums import DataModelObjectCategory
+
+SOURCE_STEP = "UNSET_REQUIRED_BY_CALLER"
+UNITS = "mm"
+
+
+def text(value):
+    try:
+        return unicode(value)
+    except Exception:
+        return str(value)
+
+
+def safe(obj, name):
+    try:
+        return text(getattr(obj, name))
+    except Exception as error:
+        return "<unavailable: %s>" % text(error)
+
+
+report = {
+    "schema_version": 1,
+    "workflow": "fusion_step_to_beam_smoke",
+    "phase": "MECHANICAL_LINE_BODY_IMPORT",
+    "status": "FAIL",
+    "ok": False,
+    "source_step": SOURCE_STEP,
+    "units": UNITS,
+    "gates": {
+        "step_file_check": None,
+        "workbench_step_import": None,
+        "spaceclaim_beam_idealization": None,
+        "mechanical_line_body_import": None,
+    },
+    "bodies": [],
+    "counts": {"all": 0, "active_line": 0, "active_solid": 0, "active_surface": 0},
+    "orientation_objects": [],
+    "warnings": [],
+    "errors": [],
+    "evidence": {},
+}
+
+try:
+    if SOURCE_STEP == "UNSET_REQUIRED_BY_CALLER":
+        report["warnings"].append("Set SOURCE_STEP and UNITS from the conversion manifest before final evidence validation.")
+    model = ExtAPI.DataModel.Project.Model
+    bodies = list(ExtAPI.DataModel.GetObjectsByType(DataModelObjectCategory.Body))
+    report["counts"]["all"] = len(bodies)
+    for body in bodies:
+        geometry_type = safe(body, "GeometryType")
+        suppressed = safe(body, "Suppressed").lower() == "true"
+        item = {
+            "name": safe(body, "Name"),
+            "geometry_type": geometry_type,
+            "model_type": safe(body, "ModelType"),
+            "suppressed": suppressed,
+            "material": safe(body, "Material"),
+            "cross_section": safe(body, "CrossSection"),
+        }
+        try:
+            geo_body = body.GetGeoBody()
+            item["geometry_id"] = int(geo_body.Id)
+            item["vertex_count"] = len(list(geo_body.Vertices))
+        except Exception as error:
+            item["geometry_probe_error"] = text(error)
+        report["bodies"].append(item)
+        if not suppressed:
+            lower = geometry_type.lower()
+            if "line" in lower:
+                report["counts"]["active_line"] += 1
+            elif "solid" in lower:
+                report["counts"]["active_solid"] += 1
+            elif "surface" in lower:
+                report["counts"]["active_surface"] += 1
+
+    for child in model.Geometry.Children:
+        type_name = safe(child.GetType(), "FullName")
+        if "Orientation" in type_name:
+            report["orientation_objects"].append({
+                "name": safe(child, "Name"),
+                "type": type_name,
+                "state": safe(child, "ObjectState"),
+            })
+
+    report["evidence"]["model_available"] = True
+    report["status"] = "BLOCKED"
+    report["warnings"].append(
+        "Inventory completed. Compare member names, section read-back, orientation coverage, and connectivity against the conversion manifest before setting PASS."
+    )
+except Exception as error:
+    report["errors"].append(text(error))
+    report["traceback"] = traceback.format_exc()
+
+print("ANSYS_STRUCTURAL_JSON:" + json.dumps(report, sort_keys=True))

--- a/MCP/Ansys/Workbench MCP/examples/spaceclaim_thinwall_step_to_beam_v252.py.template
+++ b/MCP/Ansys/Workbench MCP/examples/spaceclaim_thinwall_step_to_beam_v252.py.template
@@ -1,0 +1,73 @@
+# Python Script, API Version = V252
+#
+# This is a guarded SpaceClaim template, not a generic one-click extractor.
+# Replace every RECORDER_REQUIRED block with V252 Script Recorder output for
+# the actual Fusion member selection and confirm it against the V252 docs.
+
+import json
+import traceback
+
+SOURCE_STEP = __STEP_PATH_PY__
+UNITS = __UNITS_PY__
+MEMBER_MANIFEST = __MEMBER_MANIFEST_PY__
+
+report = {
+    "schema_version": 1,
+    "workflow": "fusion_step_to_beam_smoke",
+    "phase": "SPACECLAIM_BEAM_IDEALIZATION",
+    "status": "FAIL",
+    "ok": False,
+    "source_step": SOURCE_STEP,
+    "units": UNITS,
+    "gates": {
+        "step_file_check": True,
+        "workbench_step_import": None,
+        "spaceclaim_beam_idealization": None,
+        "mechanical_line_body_import": None,
+    },
+    "members": [],
+    "warnings": [],
+    "errors": [],
+    "evidence": {},
+}
+
+
+def require_recorded_code(member):
+    raise RuntimeError(
+        "RECORDER_REQUIRED: capture V252 Extract Beam/Create Beam selection for member "
+        + str(member.get("name"))
+    )
+
+
+def intended_profile_command(section):
+    kind = section.get("kind")
+    if kind == "rectangular_hollow":
+        return "BeamProfile.CreateRectangular(thickness, width, depth, csName, info)"
+    if kind == "circular_tube":
+        return "BeamProfile.CreateCircular(outerDiameter, innerDiameter, csName, info)"
+    if kind == "solid_rectangle":
+        return "BeamProfile.CreateFlatBar(baseWidth, depth, webRootRadius, csName, info)"
+    if kind == "custom":
+        return "Beam.ExtractProfile(selection, info)"
+    raise RuntimeError("Unsupported section kind: " + str(kind))
+
+
+try:
+    if not MEMBER_MANIFEST:
+        raise RuntimeError("Member manifest is empty")
+    for member in MEMBER_MANIFEST:
+        section = member.get("section", {})
+        report["members"].append({
+            "name": member.get("name"),
+            "source_body": member.get("source_body"),
+            "intended_profile_command": intended_profile_command(section),
+            "converted": False,
+        })
+        # RECORDER_REQUIRED: body selection, centerline extraction/construction,
+        # Beam.Create, Beam.SetOrientation, Beam.SetPosition, and body suppression.
+        require_recorded_code(member)
+except Exception as error:
+    report["errors"].append(str(error))
+    report["traceback"] = traceback.format_exc()
+
+print("ANSYS_STRUCTURAL_JSON:" + json.dumps(report, sort_keys=True))

--- a/MCP/Ansys/Workbench MCP/examples/workbench_import_step_v252.wbjn.template
+++ b/MCP/Ansys/Workbench MCP/examples/workbench_import_step_v252.wbjn.template
@@ -1,0 +1,81 @@
+SetScriptVersion(Version="25.2.170")
+
+import json
+import os
+import traceback
+
+STEP_PATH = __STEP_PATH_PY__
+PROJECT_PATH = __PROJECT_PATH_PY__
+STATUS_PATH = __STATUS_PATH_PY__
+SYSTEM_NAME = __SYSTEM_NAME_PY__
+UNITS = __UNITS_PY__
+ALLOW_OVERWRITE = __ALLOW_OVERWRITE_PY__
+OPEN_SPACECLAIM = __OPEN_SPACECLAIM_PY__
+
+
+def emit(report):
+    payload = json.dumps(report, sort_keys=True)
+    stream = open(STATUS_PATH, "w")
+    try:
+        stream.write(payload)
+    finally:
+        stream.close()
+    print("ANSYS_STRUCTURAL_JSON:" + payload)
+
+
+report = {
+    "schema_version": 1,
+    "workflow": "fusion_step_to_beam_smoke",
+    "phase": "WORKBENCH_STEP_IMPORT",
+    "status": "FAIL",
+    "ok": False,
+    "source_step": STEP_PATH,
+    "project_path": PROJECT_PATH,
+    "units": UNITS,
+    "gates": {
+        "step_file_check": None,
+        "workbench_step_import": None,
+        "spaceclaim_beam_idealization": None,
+        "mechanical_line_body_import": None,
+    },
+    "warnings": [],
+    "errors": [],
+    "evidence": {},
+}
+
+try:
+    if not os.path.isfile(STEP_PATH):
+        raise RuntimeError("STEP file does not exist: " + STEP_PATH)
+    if os.path.getsize(STEP_PATH) <= 0:
+        raise RuntimeError("STEP file is empty: " + STEP_PATH)
+    report["gates"]["step_file_check"] = True
+    if os.path.exists(PROJECT_PATH) and not ALLOW_OVERWRITE:
+        raise RuntimeError("Output project already exists; overwrite is not authorized: " + PROJECT_PATH)
+
+    template = GetTemplate(TemplateName="Static Structural", Solver="ANSYS")
+    system = template.CreateSystem()
+    system.DisplayText = SYSTEM_NAME
+    geometry = system.GetContainer(ComponentName="Geometry")
+    props = geometry.GetGeometryProperties()
+    props.GeometryImportSolidBodies = True
+    props.GeometryImportSurfaceBodies = False
+    props.GeometryImportLineBodies = False
+    props.GeometryImportAnalysisType = "AnalysisType_3D"
+    geometry.SetFile(FilePath=STEP_PATH)
+    Save(FilePath=PROJECT_PATH, Overwrite=ALLOW_OVERWRITE)
+
+    report["status"] = "BLOCKED"
+    report["evidence"]["journal_completed"] = True
+    report["evidence"]["project_saved"] = os.path.isfile(PROJECT_PATH)
+    report["warnings"].append(
+        "Workbench accepted the STEP source and saved the project, but solid inventory must be observed in SpaceClaim before STEP_IMPORT can pass."
+    )
+    if OPEN_SPACECLAIM:
+        geometry.Edit(IsSpaceClaimGeometry=True)
+        report["evidence"]["spaceclaim_edit_requested"] = True
+    emit(report)
+except Exception as error:
+    report["errors"].append(str(error))
+    report["traceback"] = traceback.format_exc()
+    emit(report)
+    raise

--- a/MCP/Ansys/Workbench MCP/pyproject.toml
+++ b/MCP/Ansys/Workbench MCP/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ansys-workbench-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server and ANSYS Mechanical ACT bridge for Workbench automation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/MCP/Ansys/Workbench MCP/pyproject.toml
+++ b/MCP/Ansys/Workbench MCP/pyproject.toml
@@ -1,7 +1,12 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "ansys-workbench-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server and ANSYS Mechanical ACT bridge for Workbench automation"
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=2.0,<3",
@@ -10,10 +15,30 @@ dependencies = [
 
 [project.optional-dependencies]
 mechanical = ["ansys-mechanical-core>=0.11"]
+workbench = [
+    "ansys-workbench-core>=0.14,<0.15",
+    "ansys-mechanical-core>=0.13,<0.14",
+    "psutil>=5.9,<8",
+]
 dev = ["pytest>=8.0,<9"]
+
+[project.scripts]
+ansys-workbench-mcp = "server:main"
+
+[tool.setuptools]
+include-package-data = true
+py-modules = ["server"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["tools*", "workbench_plugin*", "examples*"]
+
+[tool.setuptools.package-data]
+examples = ["*.json", "*.template", "*.toml"]
+workbench_plugin = ["*.xml"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
 
 [tool.uv]
-package = false
+package = true

--- a/MCP/Ansys/Workbench MCP/server.py
+++ b/MCP/Ansys/Workbench MCP/server.py
@@ -47,6 +47,21 @@ from tools.mechanical_workflows import (
 )
 
 
+from tools.workbench_session import (
+    workbench_attach_current,
+    workbench_bootstrap_current,
+    workbench_launch_managed,
+    workbench_model_execute_python,
+    workbench_model_open,
+    workbench_model_state,
+    workbench_project_inventory,
+    workbench_project_open,
+    workbench_project_save_as,
+    workbench_session_disconnect,
+    workbench_session_status,
+)
+
+
 load_dotenv()
 
 mcp = FastMCP("Ansys Workbench MCP")
@@ -379,5 +394,144 @@ def mechanical_export_evidence_tool(
     )
 
 
+@mcp.tool()
+def workbench_session_status_tool() -> dict:
+    """Inspect Workbench/Mechanical processes and managed MCP sessions."""
+    return workbench_session_status()
+
+
+@mcp.tool()
+def workbench_bootstrap_current_tool(
+    expected_project_path: str | None = None,
+    expected_system_name: str | None = None,
+    security: str = "wnua",
+    host: str = "localhost",
+    bridge_timeout: float = 10.0,
+) -> dict:
+    """Safely attach to the one existing Workbench through its live bridge."""
+    return workbench_bootstrap_current(
+        expected_project_path=expected_project_path,
+        expected_system_name=expected_system_name,
+        security=security,
+        host=host,
+        bridge_timeout=bridge_timeout,
+    )
+
+
+@mcp.tool()
+def workbench_attach_current_tool(
+    port: int,
+    security: str = "mtls",
+    host: str = "localhost",
+) -> dict:
+    """Attach to an existing Workbench instance whose StartServer port is known."""
+    return workbench_attach_current(port=port, security=security, host=host)
+
+
+@mcp.tool()
+def workbench_launch_managed_tool(
+    version: str = "252",
+    show_gui: bool = True,
+    server_workdir: str | None = None,
+    use_insecure_connection: bool = False,
+) -> dict:
+    """Launch one PyWorkbench-managed instance; refuse when Workbench already exists."""
+    return workbench_launch_managed(
+        version=version,
+        show_gui=show_gui,
+        server_workdir=server_workdir,
+        use_insecure_connection=use_insecure_connection,
+    )
+
+
+@mcp.tool()
+def workbench_project_inventory_tool(session_id: str) -> dict:
+    """List the active Workbench project and its exact internal system names."""
+    return workbench_project_inventory(session_id=session_id)
+
+
+@mcp.tool()
+def workbench_project_open_tool(session_id: str, project_path: str) -> dict:
+    """Open an existing .wbpj in a managed empty Workbench session."""
+    return workbench_project_open(session_id=session_id, project_path=project_path)
+
+
+@mcp.tool()
+def workbench_project_save_as_tool(
+    session_id: str,
+    target_path: str,
+    overwrite: bool = False,
+) -> dict:
+    """Save the active Workbench project under a new path without overwriting by default."""
+    return workbench_project_save_as(
+        session_id=session_id,
+        target_path=target_path,
+        overwrite=overwrite,
+    )
+
+
+@mcp.tool()
+def workbench_model_open_tool(
+    session_id: str,
+    system_name: str | None = None,
+    transport_mode: str | None = None,
+    connect_timeout: float = 120.0,
+    mechanical_port: int | None = None,
+) -> dict:
+    """Start and connect to the Mechanical Model for one exact Workbench system."""
+    return workbench_model_open(
+        session_id=session_id,
+        system_name=system_name,
+        transport_mode=transport_mode,
+        connect_timeout=connect_timeout,
+        mechanical_port=mechanical_port,
+    )
+
+
+@mcp.tool()
+def workbench_model_state_tool(
+    model_session_id: str,
+    expected_body_count: int | None = None,
+    expected_analysis_count: int | None = None,
+    expected_project_path: str | None = None,
+    expected_system_name: str | None = None,
+    expected_body_names: list[str] | None = None,
+    expected_analysis_names: list[str] | None = None,
+    expected_analysis_types: list[str] | None = None,
+) -> dict:
+    """Verify a Workbench-managed Mechanical Model by body and analysis counts."""
+    return workbench_model_state(
+        model_session_id=model_session_id,
+        expected_body_count=expected_body_count,
+        expected_analysis_count=expected_analysis_count,
+        expected_project_path=expected_project_path,
+        expected_system_name=expected_system_name,
+        expected_body_names=expected_body_names,
+        expected_analysis_names=expected_analysis_names,
+        expected_analysis_types=expected_analysis_types,
+    )
+
+
+@mcp.tool()
+def workbench_model_execute_python_tool(model_session_id: str, code: str) -> dict:
+    """Execute Mechanical Python in one explicitly selected model session."""
+    return workbench_model_execute_python(model_session_id=model_session_id, code=code)
+
+
+@mcp.tool()
+def workbench_session_disconnect_tool(session_id: str) -> dict:
+    """Disconnect MCP clients without closing Workbench or Mechanical processes."""
+    return workbench_session_disconnect(session_id=session_id)
+
+
+def main() -> None:
+    """Run the stdio MCP server without a Unicode startup banner."""
+
+    # Codex consumes MCP stdio and diagnostic streams as UTF-8.  Suppress the
+    # Rich/Unicode startup banner so a Windows legacy code page cannot corrupt
+    # the startup stream before the initialize handshake completes.
+    mcp.run(show_banner=False)
+
+
 if __name__ == "__main__":
-    mcp.run()
+    main()

--- a/MCP/Ansys/Workbench MCP/tests/test_beam_import_templates.py
+++ b/MCP/Ansys/Workbench MCP/tests/test_beam_import_templates.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.prepare_beam_import_smoke import prepare
+from tools.validate_beam_import_contract import validate
+
+
+def make_args(tmp_path: Path, step: Path, **overrides):
+    values = {
+        "step": str(step),
+        "project": str(tmp_path / "beam.wbpj"),
+        "output_dir": str(tmp_path / "prepared"),
+        "units": "mm",
+        "system_name": "Fixture",
+        "allow_overwrite": False,
+        "open_spaceclaim": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class BeamImportTemplateTests(unittest.TestCase):
+    def test_prepare_renders_guarded_journal_and_valid_contract(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tmp_path = Path(directory)
+            step = tmp_path / "tube.step"
+            step.write_text("ISO-10303-21;\nEND-ISO-10303-21;\n", encoding="ascii")
+            payload = prepare(make_args(tmp_path, step))
+            self.assertEqual(validate(payload), [])
+            journal = Path(payload["evidence"]["journal_path"])
+            text = journal.read_text(encoding="utf-8")
+            self.assertNotIn("__STEP_PATH_PY__", text)
+            self.assertNotIn("__UNITS_PY__", text)
+            self.assertIn(repr(str(step.resolve())), text)
+            compile("\n".join(text.splitlines()[2:]), str(journal), "exec")
+            self.assertEqual(payload["status"], "NOT_RUN")
+            self.assertIsNone(payload["gates"]["workbench_step_import"])
+
+    def test_prepare_refuses_existing_project_without_authorization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tmp_path = Path(directory)
+            step = tmp_path / "tube.step"
+            step.write_text("STEP", encoding="ascii")
+            project = tmp_path / "beam.wbpj"
+            project.write_text("existing", encoding="ascii")
+            with self.assertRaises(FileExistsError):
+                prepare(make_args(tmp_path, step, project=str(project)))
+
+    def test_contract_rejects_unobserved_pass(self):
+        payload = {
+            "schema_version": 1,
+            "workflow": "fusion_step_to_beam_smoke",
+            "phase": "PREPARED",
+            "status": "PASS",
+            "ok": True,
+            "source_step": "tube.step",
+            "units": "mm",
+            "gates": {gate: None for gate in ("step_file_check", "workbench_step_import", "spaceclaim_beam_idealization", "mechanical_line_body_import")},
+            "warnings": [],
+            "errors": [],
+            "evidence": {},
+        }
+        self.assertIn("PASS requires every smoke gate=true", validate(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/MCP/Ansys/Workbench MCP/tests/test_server_registration.py
+++ b/MCP/Ansys/Workbench MCP/tests/test_server_registration.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+
+import server
+
+
+HIGH_LEVEL_TOOLS = {
+    "workbench_session_status_tool",
+    "workbench_bootstrap_current_tool",
+    "workbench_attach_current_tool",
+    "workbench_launch_managed_tool",
+    "workbench_project_inventory_tool",
+    "workbench_project_open_tool",
+    "workbench_project_save_as_tool",
+    "workbench_model_open_tool",
+    "workbench_model_state_tool",
+    "workbench_model_execute_python_tool",
+    "workbench_session_disconnect_tool",
+}
+
+
+MECHANICAL_WORKFLOW_TOOLS = {
+    "mechanical_readiness_tool",
+    "mechanical_probe_session_tool",
+    "workbench_create_prestressed_modal_chain_tool",
+    "mechanical_geometry_inventory_tool",
+    "mechanical_import_geometry_tool",
+    "mechanical_create_named_selection_tool",
+    "mechanical_create_analysis_chain_tool",
+    "mechanical_validate_rotor_job_tool",
+    "mechanical_configure_rotor_model_tool",
+    "mechanical_validate_mesh_job_tool",
+    "mechanical_mesh_and_validate_tool",
+    "mechanical_solve_analysis_tool",
+    "mechanical_workflow_status_tool",
+    "mechanical_extract_structural_results_tool",
+    "mechanical_extract_modal_results_tool",
+    "mechanical_export_evidence_tool",
+}
+
+
+def test_server_registers_complete_merged_v020_tool_surface():
+    tools = asyncio.run(server.mcp.get_tools())
+
+    assert len(tools) == 45
+    assert HIGH_LEVEL_TOOLS <= set(tools)
+    assert MECHANICAL_WORKFLOW_TOOLS <= set(tools)

--- a/MCP/Ansys/Workbench MCP/tests/test_workbench_session.py
+++ b/MCP/Ansys/Workbench MCP/tests/test_workbench_session.py
@@ -1,0 +1,625 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tools import workbench_session as ws
+
+
+class FakeChannel:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class FakeWorkbench:
+    def __init__(self, inventory: dict | None = None) -> None:
+        self.inventory = inventory or {
+            "framework_version": "25.2",
+            "project_file": None,
+            "systems": [],
+            "system_count": 0,
+        }
+        self.started_systems: list[tuple[str, int]] = []
+        self.exit_calls = 0
+        self.scripts: list[str] = []
+        self.channel = FakeChannel()
+        self.stub = object()
+
+    def run_script_string(self, script: str):
+        self.scripts.append(script)
+        return json.dumps(self.inventory)
+
+    def start_mechanical_server(self, system_name: str, port: int = 0) -> int:
+        self.started_systems.append((system_name, port))
+        return 55123
+
+    def exit(self) -> None:
+        self.exit_calls += 1
+
+
+class FakeMechanical:
+    def __init__(self, state: dict | None = None) -> None:
+        self.state = state or {
+            "ok": True,
+            "project_directory": r"C:\project_files\dp0\SYS\MECH",
+            "model_present": True,
+            "body_count": 7,
+            "body_names": ["实体1", "实体2", "实体3", "销1", "销1 (1)", "销1 (2)", "销1 (3)"],
+            "active_body_count": 7,
+            "active_body_names": ["实体1", "实体2", "实体3", "销1", "销1 (1)", "销1 (2)", "销1 (3)"],
+            "analysis_count": 1,
+            "analyses": [{
+                "name": "Static Structural",
+                "analysis_type": "Static Structural",
+                "working_directory": r"C:\beam\beam_v2_files\dp0\SYS\MECH",
+            }],
+        }
+        self.calls: list[str] = []
+        self.exit_calls = 0
+        self._channel = FakeChannel()
+
+    def run_python_script(self, code: str):
+        self.calls.append(code)
+        if "DataModelObjectCategory" in code:
+            return json.dumps(self.state)
+        return "user-result"
+
+    def exit(self) -> None:
+        self.exit_calls += 1
+        raise AssertionError("Mechanical exit must not be called by a safe disconnect")
+
+
+class EscapedFakeMechanical(FakeMechanical):
+    """Return the ASCII-only payload produced by the Mechanical IronPython gate."""
+
+    def run_python_script(self, code: str):
+        self.calls.append(code)
+        if "DataModelObjectCategory" not in code:
+            return "user-result"
+        escape = lambda value: value.encode("unicode_escape").decode("ascii")
+        state = dict(self.state)
+        state["project_directory"] = escape(r"C:\项目_files\dp0\SYS\MECH")
+        state["body_names"] = [escape("实体1"), escape("销1")]
+        state["active_body_names"] = list(state["body_names"])
+        state["analyses"] = [
+            {
+                "name": escape("静态结构"),
+                "analysis_type": escape("Static Structural"),
+                "working_directory": escape(r"C:\项目_files\dp0\SYS\MECH"),
+            }
+        ]
+        state["named_selection_count"] = 0
+        state["named_selection_names"] = []
+        return json.dumps(state, ensure_ascii=True)
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    ws._WORKBENCH_SESSIONS.clear()
+    ws._WORKBENCH_ENDPOINT_INDEX.clear()
+    ws._MODEL_SESSIONS.clear()
+    ws._MODEL_INDEX.clear()
+    ws._MODEL_OPENING.clear()
+    ws._MODEL_ENDPOINTS.clear()
+    yield
+    ws._WORKBENCH_SESSIONS.clear()
+    ws._WORKBENCH_ENDPOINT_INDEX.clear()
+    ws._MODEL_SESSIONS.clear()
+    ws._MODEL_INDEX.clear()
+    ws._MODEL_OPENING.clear()
+    ws._MODEL_ENDPOINTS.clear()
+
+
+def mechanical_inventory() -> dict:
+    return {
+        "framework_version": "25.2",
+        "project_file": r"C:\beam\beam_v2.wbpj",
+        "systems": [
+            {
+                "name": "SYS",
+                "display_text": "Beam Assembly Static - Solid Contact V2",
+                "has_model": True,
+                "has_solution": True,
+            }
+        ],
+        "system_count": 1,
+    }
+
+
+def test_launch_refuses_second_workbench(monkeypatch):
+    monkeypatch.setattr(
+        ws,
+        "_workbench_processes",
+        lambda strict=False: [{"pid": 10, "name": "RunWB2.exe", "command_line": []}],
+    )
+    monkeypatch.setattr(
+        ws,
+        "_load_pyworkbench",
+        lambda: (_ for _ in ()).throw(AssertionError("launcher must not be loaded")),
+    )
+
+    result = ws.workbench_launch_managed()
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked_existing_workbench"
+
+
+def test_attach_current_and_inventory(monkeypatch):
+    fake = FakeWorkbench(mechanical_inventory())
+    monkeypatch.setattr(ws, "_load_pyworkbench", lambda: (lambda **_: fake, object))
+
+    attached = ws.workbench_attach_current(port=51000)
+
+    assert attached["ok"] is True
+    session_id = attached["data"]["session_id"]
+    inspected = ws.workbench_project_inventory(session_id)
+    assert inspected["ok"] is True
+    assert inspected["data"]["systems"][0]["name"] == "SYS"
+
+
+def test_project_open_blocks_different_active_project(tmp_path, monkeypatch):
+    target = tmp_path / "target.wbpj"
+    target.write_text("placeholder", encoding="utf-8")
+    fake = FakeWorkbench(mechanical_inventory())
+    session_id = "wb_test"
+    ws._WORKBENCH_SESSIONS[session_id] = ws.WorkbenchSession(
+        session_id=session_id,
+        client=fake,
+        port=51000,
+        security="insecure",
+        owned=False,
+    )
+    monkeypatch.setattr(ws, "_workbench_inventory", lambda _: mechanical_inventory())
+
+    result = ws.workbench_project_open(session_id, str(target))
+
+    assert result["ok"] is False
+    assert result["status"] == "blocked_active_project"
+    assert not any("Open(FilePath=" in script for script in fake.scripts)
+
+
+def test_project_open_verifies_target_identity(tmp_path, monkeypatch):
+    target = tmp_path / "target.wbpj"
+    target.write_text("placeholder", encoding="utf-8")
+    fake = FakeWorkbench()
+    session_id = "wb_test"
+    ws._WORKBENCH_SESSIONS[session_id] = ws.WorkbenchSession(
+        session_id=session_id,
+        client=fake,
+        port=51000,
+        security="insecure",
+        owned=True,
+    )
+    before = {
+        "framework_version": "25.2",
+        "project_file": None,
+        "systems": [],
+        "system_count": 0,
+    }
+    after = dict(before, project_file=str(target.resolve()))
+    inventories = iter((before, after))
+    monkeypatch.setattr(ws, "_workbench_inventory", lambda _: next(inventories))
+
+    result = ws.workbench_project_open(session_id, str(target))
+
+    assert result["ok"] is True
+    assert result["status"] == "opened"
+    assert result["evidence"]["project_path"] == str(target.resolve())
+    assert any("Open(FilePath=" in script for script in fake.scripts)
+
+
+def test_project_save_as_refuses_overwrite_and_verifies_identity(tmp_path, monkeypatch):
+    fake = FakeWorkbench(mechanical_inventory())
+    session_id = "wb_test"
+    ws._WORKBENCH_SESSIONS[session_id] = ws.WorkbenchSession(
+        session_id=session_id,
+        client=fake,
+        port=51000,
+        security="insecure",
+        owned=True,
+    )
+    existing = tmp_path / "existing.wbpj"
+    existing.write_text("keep", encoding="utf-8")
+
+    blocked = ws.workbench_project_save_as(session_id, str(existing))
+
+    assert blocked["ok"] is False
+    assert blocked["status"] == "target_exists"
+    assert fake.scripts == []
+
+    target = tmp_path / "nested" / "saved.wbpj"
+    after = dict(mechanical_inventory(), project_file=str(target.resolve()))
+    monkeypatch.setattr(ws, "_workbench_inventory", lambda _: after)
+
+    saved = ws.workbench_project_save_as(session_id, str(target))
+
+    assert saved["ok"] is True
+    assert saved["status"] == "saved"
+    assert target.parent.is_dir()
+    assert any("Save(FilePath=" in script and "Overwrite=False" in script for script in fake.scripts)
+
+
+def test_model_open_is_unique_and_idempotent(monkeypatch):
+    workbench = FakeWorkbench(mechanical_inventory())
+    mechanical = FakeMechanical()
+    session_id = "wb_test"
+    ws._WORKBENCH_SESSIONS[session_id] = ws.WorkbenchSession(
+        session_id=session_id,
+        client=workbench,
+        port=51000,
+        security="insecure",
+        owned=False,
+    )
+    monkeypatch.setattr(ws, "_workbench_inventory", lambda _: mechanical_inventory())
+    monkeypatch.setattr(ws, "_load_pymechanical", lambda: (lambda **_: mechanical))
+
+    first = ws.workbench_model_open(session_id=session_id)
+    second = ws.workbench_model_open(session_id=session_id)
+
+    assert first["ok"] is True
+    assert first["status"] == "model_ready"
+    assert first["evidence"]["mechanical_port"] == 55123
+    assert workbench.started_systems == [("SYS", 0)]
+    assert second["ok"] is True
+    assert second["status"] == "already_open"
+    assert second["idempotent"] is True
+    assert second["data"]["model_session_id"] == first["data"]["model_session_id"]
+
+
+def test_model_state_enforces_expected_counts(monkeypatch):
+    mechanical = FakeMechanical()
+    workbench = FakeWorkbench(mechanical_inventory())
+    ws._WORKBENCH_SESSIONS["wb_test"] = ws.WorkbenchSession(
+        session_id="wb_test",
+        client=workbench,
+        port=51000,
+        security="insecure",
+        owned=False,
+    )
+    model_id = "model_test"
+    ws._MODEL_SESSIONS[model_id] = ws.ModelSession(
+        model_session_id=model_id,
+        workbench_session_id="wb_test",
+        system_name="SYS",
+        client=mechanical,
+        port=55123,
+        transport_mode="insecure",
+        project_file=ws._normalize_path(r"C:\beam\beam_v2.wbpj"),
+    )
+
+    result = ws.workbench_model_state(
+        model_session_id=model_id,
+        expected_body_count=7,
+        expected_analysis_count=2,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "model_gate_failed"
+    assert "Expected 2 analyses" in result["errors"][0]
+
+
+def test_disconnect_never_terminates_mechanical():
+    workbench = FakeWorkbench()
+    mechanical = FakeMechanical()
+    session_id = "wb_test"
+    model_id = "model_test"
+    ws._WORKBENCH_SESSIONS[session_id] = ws.WorkbenchSession(
+        session_id=session_id,
+        client=workbench,
+        port=51000,
+        security="insecure",
+        owned=False,
+    )
+    ws._MODEL_SESSIONS[model_id] = ws.ModelSession(
+        model_session_id=model_id,
+        workbench_session_id=session_id,
+        system_name="SYS",
+        client=mechanical,
+        port=55123,
+        transport_mode="insecure",
+    )
+    ws._MODEL_INDEX[(session_id, "SYS")] = model_id
+
+    result = ws.workbench_session_disconnect(session_id)
+
+    assert result["ok"] is True
+    assert workbench.exit_calls == 0
+    assert mechanical.exit_calls == 0
+    assert workbench.channel is None
+    assert mechanical._channel is None
+    assert session_id not in ws._WORKBENCH_SESSIONS
+    assert model_id not in ws._MODEL_SESSIONS
+
+
+def test_disconnect_supports_workbench_client_without_exit_method():
+    channel = FakeChannel()
+    client = SimpleNamespace(channel=channel, stub=object())
+    ws._WORKBENCH_SESSIONS["wb_test"] = ws.WorkbenchSession(
+        session_id="wb_test",
+        client=client,
+        port=51000,
+        security="mtls",
+        owned=False,
+    )
+
+    result = ws.workbench_session_disconnect("wb_test")
+
+    assert result["ok"] is True
+    assert channel.close_calls == 1
+    assert client.channel is None
+    assert client.stub is None
+
+
+def test_model_state_enforces_exact_project_system_bodies_and_analysis_type():
+    workbench = FakeWorkbench(mechanical_inventory())
+    mechanical = FakeMechanical()
+    ws._WORKBENCH_SESSIONS["wb_test"] = ws.WorkbenchSession(
+        session_id="wb_test",
+        client=workbench,
+        port=51000,
+        security="mtls",
+        owned=False,
+    )
+    ws._MODEL_SESSIONS["model_test"] = ws.ModelSession(
+        model_session_id="model_test",
+        workbench_session_id="wb_test",
+        system_name="SYS",
+        client=mechanical,
+        port=55123,
+        transport_mode="insecure",
+        project_file=ws._normalize_path(r"C:\beam\beam_v2.wbpj"),
+    )
+
+    result = ws.workbench_model_state(
+        model_session_id="model_test",
+        expected_project_path=r"C:\beam\beam_v2.wbpj",
+        expected_system_name="SYS",
+        expected_body_count=7,
+        expected_body_names=["实体1", "实体2", "实体3", "销1", "销1 (1)", "销1 (2)", "销1 (3)"],
+        expected_analysis_count=1,
+        expected_analysis_names=["Static Structural"],
+        expected_analysis_types=["Static Structural"],
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "model_ready"
+    assert result["evidence"]["project_file"] == ws._normalize_path(r"C:\beam\beam_v2.wbpj")
+
+
+def test_mechanical_state_decodes_unicode_escape_and_handles_empty_named_selections():
+    mechanical = EscapedFakeMechanical(
+        {
+            "ok": True,
+            "application_version": "25.2",
+            "project_directory": "unused",
+            "model_present": True,
+            "body_count": 2,
+            "body_names": [],
+            "active_body_count": 2,
+            "active_body_names": [],
+            "analysis_count": 1,
+            "analyses": [],
+        }
+    )
+
+    state = ws._mechanical_state(mechanical)
+
+    assert state["project_directory"] == r"C:\项目_files\dp0\SYS\MECH"
+    assert state["body_names"] == ["实体1", "销1"]
+    assert state["active_body_names"] == ["实体1", "销1"]
+    assert state["analyses"][0]["name"] == "静态结构"
+    assert state["named_selection_count"] == 0
+    assert state["named_selection_names"] == []
+    emitted = mechanical.calls[-1]
+    assert "unicode_escape" in emitted
+    assert 'getattr(model, "NamedSelections", None)' in emitted
+    assert "DataModelObjectCategory.NamedSelection" in emitted
+
+
+def test_launch_fails_closed_when_process_inventory_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        ws,
+        "_workbench_processes",
+        lambda strict=False: (_ for _ in ()).throw(RuntimeError("inventory unavailable")),
+    )
+    monkeypatch.setattr(
+        ws,
+        "_load_pyworkbench",
+        lambda: (_ for _ in ()).throw(AssertionError("launcher must not be loaded")),
+    )
+
+    result = ws.workbench_launch_managed()
+
+    assert result["ok"] is False
+    assert result["status"] == "launch_failed"
+    assert "inventory unavailable" in result["errors"][0]
+
+
+def test_model_open_reuses_cached_endpoint_after_connect_failure(monkeypatch):
+    workbench = FakeWorkbench(mechanical_inventory())
+    mechanical = FakeMechanical()
+    session_id = "wb_test"
+    ws._WORKBENCH_SESSIONS[session_id] = ws.WorkbenchSession(
+        session_id=session_id,
+        client=workbench,
+        port=51000,
+        security="wnua",
+        owned=False,
+    )
+    calls = []
+
+    def connect(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError("transient connect failure")
+        return mechanical
+
+    monkeypatch.setattr(ws, "_load_pymechanical", lambda: connect)
+
+    first = ws.workbench_model_open(session_id=session_id)
+    second = ws.workbench_model_open(session_id=session_id)
+
+    assert first["ok"] is False
+    assert second["ok"] is True
+    assert workbench.started_systems == [("SYS", 0)]
+    assert len(calls) == 2
+    assert calls[0]["transport_mode"] is None
+    assert calls[1]["port"] == 55123
+
+
+def test_bootstrap_current_is_idempotent_and_identity_gated(monkeypatch):
+    expected_project = r"C:\beam\beam_v2.wbpj"
+    fake = FakeWorkbench(mechanical_inventory())
+    connect_calls = []
+
+    monkeypatch.setattr(
+        ws,
+        "_process_inventory",
+        lambda strict=False: [
+            {"pid": 10, "parent_pid": 1, "name": "RunWB2.exe"},
+            {"pid": 11, "parent_pid": 10, "name": "AnsysFWW.exe"},
+            {"pid": 12, "parent_pid": 11, "name": "AnsysWBU.exe"},
+        ],
+    )
+    monkeypatch.setattr(
+        ws,
+        "_exclusive_launch_guard",
+        lambda timeout=30.0: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        ws,
+        "_bootstrap_bridge_report",
+        lambda timeout: {
+            "ok": True,
+            "pid": 11,
+            "server_port": 57117,
+            "project_file": expected_project,
+            "systems": ["SYS"],
+            "start_called": False,
+        },
+    )
+
+    def connect_workbench(**kwargs):
+        connect_calls.append(kwargs)
+        return fake
+
+    monkeypatch.setattr(ws, "_load_pyworkbench", lambda: (connect_workbench, object))
+
+    first = ws.workbench_bootstrap_current(
+        expected_project_path=expected_project,
+        expected_system_name="SYS",
+    )
+    second = ws.workbench_bootstrap_current(
+        expected_project_path=expected_project,
+        expected_system_name="SYS",
+    )
+
+    assert first["ok"] is True
+    assert first["status"] == "bootstrapped"
+    assert second["ok"] is True
+    assert second["status"] == "already_bootstrapped"
+    assert first["data"]["session_id"] == second["data"]["session_id"]
+    assert connect_calls == [
+        {"port": 57117, "host": "localhost", "security": "wnua"}
+    ]
+
+
+def test_process_inventory_strict_fails_on_candidate_access_error(monkeypatch):
+    class Candidate:
+        info = {"pid": 99, "name": "AnsysFWW.exe"}
+
+        def as_dict(self, attrs):
+            raise PermissionError("access denied")
+
+    fake_psutil = SimpleNamespace(process_iter=lambda attrs: [Candidate()])
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    with pytest.raises(RuntimeError, match="candidate ANSYS process"):
+        ws._process_inventory(strict=True)
+
+
+def test_bootstrap_bridge_report_rejects_execution_failure(monkeypatch):
+    monkeypatch.setattr(
+        ws,
+        "socket_timer_execute_python",
+        lambda code, timeout: {
+            "ok": True,
+            "response": {"ok": True, "execution": {"ok": False, "stderr": "boom"}},
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="execution failed"):
+        ws._bootstrap_bridge_report(timeout=1.0)
+
+
+def test_model_open_attaches_explicit_existing_port_without_start(monkeypatch):
+    workbench = FakeWorkbench(mechanical_inventory())
+    mechanical = FakeMechanical()
+    ws._WORKBENCH_SESSIONS["wb_test"] = ws.WorkbenchSession(
+        session_id="wb_test",
+        client=workbench,
+        port=57117,
+        security="wnua",
+        owned=False,
+    )
+    calls = []
+
+    def connect(**kwargs):
+        calls.append(kwargs)
+        return mechanical
+
+    monkeypatch.setattr(ws, "_load_pymechanical", lambda: connect)
+
+    result = ws.workbench_model_open(
+        session_id="wb_test",
+        system_name="SYS",
+        mechanical_port=59120,
+    )
+
+    assert result["ok"] is True
+    assert workbench.started_systems == []
+    assert calls[0]["port"] == 59120
+    assert calls[0]["transport_mode"] is None
+
+
+def test_model_execute_refuses_when_identity_gate_fails(monkeypatch):
+    workbench = FakeWorkbench(mechanical_inventory())
+    mechanical = FakeMechanical()
+    ws._WORKBENCH_SESSIONS["wb_test"] = ws.WorkbenchSession(
+        session_id="wb_test",
+        client=workbench,
+        port=57117,
+        security="wnua",
+        owned=False,
+    )
+    ws._MODEL_SESSIONS["model_test"] = ws.ModelSession(
+        model_session_id="model_test",
+        workbench_session_id="wb_test",
+        system_name="SYS",
+        client=mechanical,
+        port=59120,
+        transport_mode=None,
+        project_file=ws._normalize_path(r"C:\beam\beam_v2.wbpj"),
+    )
+    monkeypatch.setattr(
+        ws,
+        "workbench_model_state",
+        lambda **kwargs: {
+            "ok": False,
+            "status": "model_gate_failed",
+            "errors": ["project switched"],
+        },
+    )
+
+    result = ws.workbench_model_execute_python("model_test", "1 + 1")
+
+    assert result["ok"] is False
+    assert result["status"] == "identity_gate_failed"
+    assert mechanical.calls == []

--- a/MCP/Ansys/Workbench MCP/tests/test_workbench_session.py
+++ b/MCP/Ansys/Workbench MCP/tests/test_workbench_session.py
@@ -623,3 +623,40 @@ def test_model_execute_refuses_when_identity_gate_fails(monkeypatch):
     assert result["ok"] is False
     assert result["status"] == "identity_gate_failed"
     assert mechanical.calls == []
+
+
+def test_bootstrap_bridge_report_preserves_unicode_project_path(monkeypatch):
+    captured: dict[str, str] = {}
+    expected_path = r"D:\工程文件\ansys\0001.wbpj"
+
+    def fake_socket_execute(code: str, timeout: float) -> dict:
+        captured["code"] = code
+        report = {
+            "ok": True,
+            "phase": "SERVER_REUSE_OR_START_ONCE",
+            "pid": 1234,
+            "server_port": 57117,
+            "project_file": expected_path,
+            "systems": ["SYS"],
+            "start_called": False,
+        }
+        return {
+            "ok": True,
+            "response": {
+                "ok": True,
+                "execution": {
+                    "ok": True,
+                    "stdout": "WB_BOOTSTRAP_JSON:"
+                    + json.dumps(report, ensure_ascii=True)
+                    + "\n",
+                },
+            },
+        }
+
+    monkeypatch.setattr(ws, "socket_timer_execute_python", fake_socket_execute)
+
+    result = ws._bootstrap_bridge_report(timeout=1.0)
+
+    assert result["project_file"] == expected_path
+    assert "unicode(GetProjectFile())" in captured["code"]
+    assert "str(GetProjectFile())" not in captured["code"]

--- a/MCP/Ansys/Workbench MCP/tools/prepare_beam_import_smoke.py
+++ b/MCP/Ansys/Workbench MCP/tools/prepare_beam_import_smoke.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "examples" / "workbench_import_step_v252.wbjn.template"
+
+
+def render(step: Path, project: Path, status: Path, system_name: str, units: str, allow_overwrite: bool, open_spaceclaim: bool) -> str:
+    content = TEMPLATE.read_text(encoding="utf-8")
+    replacements = {
+        "__STEP_PATH_PY__": repr(str(step)),
+        "__PROJECT_PATH_PY__": repr(str(project)),
+        "__STATUS_PATH_PY__": repr(str(status)),
+        "__SYSTEM_NAME_PY__": repr(system_name),
+        "__UNITS_PY__": repr(units),
+        "__ALLOW_OVERWRITE_PY__": repr(bool(allow_overwrite)),
+        "__OPEN_SPACECLAIM_PY__": repr(bool(open_spaceclaim)),
+    }
+    for token, value in replacements.items():
+        content = content.replace(token, value)
+    unresolved = [token for token in replacements if token in content]
+    if unresolved:
+        raise RuntimeError("Unresolved template tokens: " + ", ".join(unresolved))
+    return content
+
+
+def prepare(args: argparse.Namespace) -> dict:
+    step = Path(args.step).expanduser().resolve()
+    project = Path(args.project).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    if step.suffix.lower() not in {".step", ".stp"}:
+        raise ValueError("Input must use .step or .stp")
+    if not step.is_file() or step.stat().st_size <= 0:
+        raise FileNotFoundError("STEP file is missing or empty: %s" % step)
+    if project.exists() and not args.allow_overwrite:
+        raise FileExistsError("Project exists and overwrite is not authorized: %s" % project)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    journal = output_dir / "workbench_import_step_v252.wbjn"
+    status = output_dir / "workbench_import_status.json"
+    request = output_dir / "beam_import_smoke_request.json"
+    if journal.exists() and not args.allow_overwrite:
+        raise FileExistsError("Rendered journal exists and overwrite is not authorized: %s" % journal)
+    journal.write_text(
+        render(step, project, status, args.system_name, args.units, args.allow_overwrite, args.open_spaceclaim),
+        encoding="utf-8",
+    )
+    payload = {
+        "schema_version": 1,
+        "workflow": "fusion_step_to_beam_smoke",
+        "phase": "PREPARED",
+        "status": "NOT_RUN",
+        "ok": False,
+        "source_step": str(step),
+        "project_path": str(project),
+        "units": args.units,
+        "gates": {
+            "step_file_check": True,
+            "workbench_step_import": None,
+            "spaceclaim_beam_idealization": None,
+            "mechanical_line_body_import": None,
+        },
+        "members": [],
+        "warnings": ["Live ANSYS validation has not run."],
+        "errors": [],
+        "evidence": {"journal_path": str(journal), "status_path": str(status), "step_bytes": step.stat().st_size},
+    }
+    request.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prepare a guarded Workbench STEP import smoke journal.")
+    parser.add_argument("--step", required=True)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--units", choices=["mm", "m", "in"], default="mm")
+    parser.add_argument("--system-name", default="Fusion STEP Beam Intake")
+    parser.add_argument("--allow-overwrite", action="store_true")
+    parser.add_argument("--open-spaceclaim", action="store_true")
+    args = parser.parse_args()
+    try:
+        print(json.dumps(prepare(args), indent=2, ensure_ascii=False))
+        return 0
+    except Exception as error:
+        print(json.dumps({"ok": False, "error": str(error)}, ensure_ascii=False))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/MCP/Ansys/Workbench MCP/tools/validate_beam_import_contract.py
+++ b/MCP/Ansys/Workbench MCP/tools/validate_beam_import_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REQUIRED = {"schema_version", "workflow", "phase", "status", "ok", "source_step", "units", "gates", "warnings", "errors", "evidence"}
+GATES = ("step_file_check", "workbench_step_import", "spaceclaim_beam_idealization", "mechanical_line_body_import")
+PHASES = {"PREPARED", "WORKBENCH_STEP_IMPORT", "SPACECLAIM_BEAM_IDEALIZATION", "MECHANICAL_LINE_BODY_IMPORT"}
+STATUSES = {"NOT_RUN", "BLOCKED", "FAIL", "PASS"}
+
+
+def validate(data: dict) -> list[str]:
+    errors = []
+    missing = sorted(REQUIRED - set(data))
+    if missing:
+        errors.append("missing keys: " + ", ".join(missing))
+    if data.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if data.get("workflow") != "fusion_step_to_beam_smoke":
+        errors.append("workflow must be fusion_step_to_beam_smoke")
+    if data.get("phase") not in PHASES:
+        errors.append("invalid phase")
+    if data.get("status") not in STATUSES:
+        errors.append("invalid status")
+    if data.get("units") not in {"mm", "m", "in"}:
+        errors.append("units must be mm, m, or in")
+    if not isinstance(data.get("ok"), bool):
+        errors.append("ok must be boolean")
+    gates = data.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("gates must be an object")
+    else:
+        for gate in GATES:
+            if gate not in gates:
+                errors.append("missing gate: " + gate)
+            elif gates[gate] not in {True, False, None}:
+                errors.append("gate must be true, false, or null: " + gate)
+    for key in ("warnings", "errors"):
+        if not isinstance(data.get(key), list):
+            errors.append(key + " must be an array")
+    if data.get("status") == "PASS":
+        if data.get("ok") is not True:
+            errors.append("PASS requires ok=true")
+        if isinstance(gates, dict) and any(gates.get(gate) is not True for gate in GATES):
+            errors.append("PASS requires every smoke gate=true")
+        if data.get("errors"):
+            errors.append("PASS requires an empty errors array")
+    if data.get("ok") is True and data.get("status") != "PASS":
+        errors.append("ok=true requires status=PASS")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(json.dumps({"ok": False, "errors": ["usage: validate_beam_import_contract.py result.json"]}))
+        return 2
+    try:
+        data = json.loads(Path(argv[1]).read_text(encoding="utf-8"))
+    except Exception as error:
+        print(json.dumps({"ok": False, "errors": [str(error)]}))
+        return 2
+    errors = validate(data)
+    print(json.dumps({"ok": not errors, "errors": errors}, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/MCP/Ansys/Workbench MCP/tools/workbench_bridge.py
+++ b/MCP/Ansys/Workbench MCP/tools/workbench_bridge.py
@@ -171,24 +171,53 @@ def launch_workbench_journal(
     if extra_args:
         cmd.extend(extra_args)
 
-    stdout = stdout_path.open("w", encoding="utf-8", errors="replace")
-    stderr = stderr_path.open("w", encoding="utf-8", errors="replace")
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(run_cwd),
-        stdout=stdout,
-        stderr=stderr,
-        stdin=subprocess.DEVNULL,
-        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-    )
-    stdout.close()
-    stderr.close()
+    stdout_path.touch()
+    stderr_path.touch()
+    if os.name == "nt":
+        launch_exe = cmd[0]
+        launch_args = cmd[1:]
+        if Path(launch_exe).suffix.lower() in {".bat", ".cmd"}:
+            launch_args = [
+                "/d",
+                "/s",
+                "/c",
+                "call",
+                '"' + launch_exe + '"',
+                *launch_args,
+            ]
+            launch_exe = os.environ.get("ComSpec", "cmd.exe")
+        launch_env = os.environ.copy()
+        launch_env["WORKBENCH_MCP_LAUNCH_EXE"] = launch_exe
+        launch_env["WORKBENCH_MCP_LAUNCH_ARGS"] = json.dumps(launch_args)
+        launch_env["WORKBENCH_MCP_LAUNCH_CWD"] = str(run_cwd)
+        launcher = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "$a = ConvertFrom-Json $env:WORKBENCH_MCP_LAUNCH_ARGS; "
+                "$p = Start-Process -FilePath $env:WORKBENCH_MCP_LAUNCH_EXE "
+                "-ArgumentList $a -WorkingDirectory $env:WORKBENCH_MCP_LAUNCH_CWD "
+                "-PassThru; $p.Id",
+            ],
+            text=True,
+            capture_output=True,
+            env=launch_env,
+            timeout=30,
+        )
+        if launcher.returncode != 0:
+            raise RuntimeError(launcher.stderr.strip() or "Start-Process failed")
+        pid = int(launcher.stdout.strip().splitlines()[-1])
+    else:
+        proc = subprocess.Popen(cmd, cwd=str(run_cwd))
+        pid = proc.pid
 
     payload = {
         "job_id": job_id,
         "kind": "workbench_journal",
         "status": "running",
-        "pid": proc.pid,
+        "pid": pid,
         "command": cmd,
         "cwd": str(run_cwd),
         "journal_path": str(journal),
@@ -235,24 +264,41 @@ def launch_mechanical_script(
     if script_args:
         cmd.extend(["--script-args", script_args])
 
-    stdout = stdout_path.open("w", encoding="utf-8", errors="replace")
-    stderr = stderr_path.open("w", encoding="utf-8", errors="replace")
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(script.parent),
-        stdout=stdout,
-        stderr=stderr,
-        stdin=subprocess.DEVNULL,
-        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-    )
-    stdout.close()
-    stderr.close()
+    stdout_path.touch()
+    stderr_path.touch()
+    if os.name == "nt":
+        launch_env = os.environ.copy()
+        launch_env["WORKBENCH_MCP_LAUNCH_EXE"] = cmd[0]
+        launch_env["WORKBENCH_MCP_LAUNCH_ARGS"] = json.dumps(cmd[1:])
+        launch_env["WORKBENCH_MCP_LAUNCH_CWD"] = str(script.parent)
+        launcher = subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "$a = ConvertFrom-Json $env:WORKBENCH_MCP_LAUNCH_ARGS; "
+                "$p = Start-Process -FilePath $env:WORKBENCH_MCP_LAUNCH_EXE "
+                "-ArgumentList $a -WorkingDirectory $env:WORKBENCH_MCP_LAUNCH_CWD "
+                "-PassThru; $p.Id",
+            ],
+            text=True,
+            capture_output=True,
+            env=launch_env,
+            timeout=30,
+        )
+        if launcher.returncode != 0:
+            raise RuntimeError(launcher.stderr.strip() or "Start-Process failed")
+        pid = int(launcher.stdout.strip().splitlines()[-1])
+    else:
+        proc = subprocess.Popen(cmd, cwd=str(script.parent))
+        pid = proc.pid
 
     payload = {
         "job_id": job_id,
         "kind": "mechanical_script",
         "status": "running",
-        "pid": proc.pid,
+        "pid": pid,
         "command": cmd,
         "cwd": str(script.parent),
         "script_path": str(script),

--- a/MCP/Ansys/Workbench MCP/tools/workbench_session.py
+++ b/MCP/Ansys/Workbench MCP/tools/workbench_session.py
@@ -244,7 +244,7 @@ def _workbench_inventory(client: Any) -> dict[str, Any]:
 def _safe_attr(obj, name):
     try:
         value = getattr(obj, name)
-        return None if value is None else str(value)
+        return None if value is None else unicode(value)
     except Exception:
         return None
 
@@ -256,14 +256,14 @@ def _has_component(system, component_name):
 
 project_file = None
 try:
-    project_file = str(GetProjectFile())
+    project_file = unicode(GetProjectFile())
 except Exception:
     project_file = None
 
 systems = []
 for system in GetAllSystems():
     systems.append({
-        "name": str(system.Name),
+            "name": unicode(system.Name),
         "display_text": _safe_attr(system, "DisplayText"),
         "template_name": _safe_attr(system, "TemplateName"),
         "has_engineering_data": _has_component(system, "Engineering Data"),
@@ -274,7 +274,7 @@ for system in GetAllSystems():
     })
 
 report = {
-    "framework_version": str(GetFrameworkVersion()),
+    "framework_version": unicode(GetFrameworkVersion()),
     "project_file": project_file,
     "systems": systems,
     "system_count": len(systems),
@@ -375,8 +375,8 @@ try:
         "ok": server_port > 0,
         "pid": int(os.getpid()),
         "server_port": server_port,
-        "project_file": str(GetProjectFile()),
-        "systems": [str(system.Name) for system in GetAllSystems()],
+            "project_file": unicode(GetProjectFile()),
+            "systems": [unicode(system.Name) for system in GetAllSystems()],
         "start_called": start_called,
     })
 except Exception as exc:

--- a/MCP/Ansys/Workbench MCP/tools/workbench_session.py
+++ b/MCP/Ansys/Workbench MCP/tools/workbench_session.py
@@ -1,0 +1,1238 @@
+from __future__ import annotations
+
+"""Session-aware Workbench and Mechanical control.
+
+This module adds the missing Workbench Project Schematic layer on top of the
+existing Mechanical queue/socket bridge.  It deliberately refuses to launch a
+second Workbench while an unmanaged Workbench process is already running.
+
+PyWorkbench and PyMechanical are imported lazily so the base MCP server can
+still start and report a clear dependency error before the optional packages
+are installed.
+"""
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import importlib.util
+import json
+import os
+from pathlib import Path
+import socket
+import threading
+import time
+import uuid
+from typing import Any
+
+from tools.workbench_socket_timer import socket_timer_execute_python
+
+
+_LOCK = threading.RLock()
+_WORKBENCH_SESSIONS: dict[str, "WorkbenchSession"] = {}
+_WORKBENCH_ENDPOINT_INDEX: dict[tuple[str, int, str], str] = {}
+_MODEL_SESSIONS: dict[str, "ModelSession"] = {}
+_MODEL_INDEX: dict[tuple[str, str], str] = {}
+_MODEL_OPENING: set[tuple[str, str]] = set()
+_MODEL_ENDPOINTS: dict[tuple[str, str], int] = {}
+
+
+@dataclass
+class WorkbenchSession:
+    session_id: str
+    client: Any
+    port: int
+    security: str
+    owned: bool
+    host: str = "localhost"
+    launcher: Any | None = None
+    process_id: int | None = None
+    created_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class ModelSession:
+    model_session_id: str
+    workbench_session_id: str
+    system_name: str
+    client: Any
+    port: int
+    transport_mode: str | None
+    project_file: str | None = None
+    created_at: float = field(default_factory=time.time)
+
+
+def _reply(
+    *,
+    ok: bool,
+    status: str,
+    phase: str,
+    data: dict[str, Any] | None = None,
+    changed: bool = False,
+    idempotent: bool = False,
+    evidence: dict[str, Any] | None = None,
+    warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "status": status,
+        "phase": phase,
+        "changed": changed,
+        "idempotent": idempotent,
+        "data": data or {},
+        "evidence": evidence or {},
+        "warnings": warnings or [],
+        "errors": errors or [],
+    }
+
+
+def _load_pyworkbench() -> tuple[Any, Any]:
+    try:
+        from ansys.workbench.core import connect_workbench
+        from ansys.workbench.core.workbench_launcher import Launcher
+    except Exception as exc:  # pragma: no cover - exact import error is environment specific
+        raise RuntimeError(
+            "ansys-workbench-core is required; install the MCP 'workbench' extra"
+        ) from exc
+    return connect_workbench, Launcher
+
+
+def _load_pymechanical() -> Any:
+    try:
+        from ansys.mechanical.core import connect_to_mechanical
+    except Exception as exc:  # pragma: no cover - exact import error is environment specific
+        raise RuntimeError(
+            "ansys-mechanical-core is required; install the MCP 'mechanical' extra"
+        ) from exc
+    return connect_to_mechanical
+
+
+def _normalize_path(value: str | os.PathLike[str] | None) -> str | None:
+    if not value:
+        return None
+    return os.path.normcase(os.path.abspath(os.path.normpath(os.fspath(value))))
+
+
+def _process_inventory(strict: bool = False) -> list[dict[str, Any]]:
+    try:
+        import psutil
+    except Exception as exc:
+        if strict:
+            raise RuntimeError(
+                "Cannot enforce the single-Workbench gate because psutil is unavailable"
+            ) from exc
+        return []
+
+    rows: list[dict[str, Any]] = []
+    candidate_names = {"runwb2.exe", "ansysfww.exe", "ansyswbu.exe"}
+    for proc in psutil.process_iter(["pid", "name"]):
+        summary = proc.info
+        name = str(summary.get("name") or "")
+        if name.lower() not in candidate_names:
+            continue
+        try:
+            info = proc.as_dict(
+                attrs=["pid", "ppid", "name", "create_time", "cmdline"]
+            )
+            rows.append(
+                {
+                    "pid": int(info["pid"]),
+                    "parent_pid": int(info.get("ppid") or 0),
+                    "name": str(info.get("name") or name),
+                    "created_at": float(info.get("create_time") or 0.0),
+                    "command_line": [str(item) for item in (info.get("cmdline") or [])],
+                }
+            )
+        except Exception as exc:
+            if strict:
+                raise RuntimeError(
+                    f"Cannot inspect candidate ANSYS process {name} PID "
+                    f"{summary.get('pid')}: {exc}"
+                ) from exc
+            continue
+    rows.sort(key=lambda row: (row["created_at"], row["pid"]))
+    return rows
+
+
+def _workbench_processes(strict: bool = False) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in _process_inventory(strict=strict)
+        if row["name"].lower() in {"runwb2.exe", "ansysfww.exe"}
+    ]
+
+
+@contextmanager
+def _exclusive_launch_guard(timeout: float = 30.0):
+    """Serialize launch preflight across MCP processes.
+
+    The OS releases the byte-range lock if the MCP process dies.  The lock file
+    contains no session data and lives outside the source checkout.
+    """
+
+    state_root = Path(
+        os.environ.get("LOCALAPPDATA") or os.environ.get("TEMP") or os.getcwd()
+    ) / "ansys-workbench-mcp"
+    state_root.mkdir(parents=True, exist_ok=True)
+    lock_path = state_root / "workbench-launch.lock"
+    stream = lock_path.open("a+b")
+    acquired = False
+    deadline = time.time() + max(0.0, float(timeout))
+    try:
+        stream.seek(0, os.SEEK_END)
+        if stream.tell() == 0:
+            stream.write(b"\0")
+            stream.flush()
+        while not acquired:
+            try:
+                stream.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+                else:  # pragma: no cover - this MCP is deployed on Windows
+                    import fcntl
+
+                    fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except (OSError, BlockingIOError):
+                if time.time() >= deadline:
+                    raise RuntimeError("Timed out waiting for the global Workbench launch lock")
+                time.sleep(0.1)
+        yield
+    finally:
+        if acquired:
+            try:
+                stream.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+                else:  # pragma: no cover - this MCP is deployed on Windows
+                    import fcntl
+
+                    fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+        stream.close()
+
+
+def _port_is_open(port: int, host: str = "127.0.0.1", timeout: float = 0.4) -> bool:
+    try:
+        with socket.create_connection((host, int(port)), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _run_workbench_json(client: Any, body: str) -> dict[str, Any]:
+    script = "import json\n" + body.rstrip() + "\nwb_script_result=json.dumps(report)"
+    result = client.run_script_string(script)
+    if isinstance(result, dict):
+        return result
+    if not isinstance(result, str):
+        raise RuntimeError(f"Unexpected Workbench result type: {type(result).__name__}")
+    decoded = json.loads(result)
+    if not isinstance(decoded, dict):
+        raise RuntimeError("Workbench JSON result must be an object")
+    return decoded
+
+
+def _workbench_inventory(client: Any) -> dict[str, Any]:
+    return _run_workbench_json(
+        client,
+        r'''
+def _safe_attr(obj, name):
+    try:
+        value = getattr(obj, name)
+        return None if value is None else str(value)
+    except Exception:
+        return None
+
+def _has_component(system, component_name):
+    try:
+        return system.GetComponent(Name=component_name) is not None
+    except Exception:
+        return False
+
+project_file = None
+try:
+    project_file = str(GetProjectFile())
+except Exception:
+    project_file = None
+
+systems = []
+for system in GetAllSystems():
+    systems.append({
+        "name": str(system.Name),
+        "display_text": _safe_attr(system, "DisplayText"),
+        "template_name": _safe_attr(system, "TemplateName"),
+        "has_engineering_data": _has_component(system, "Engineering Data"),
+        "has_geometry": _has_component(system, "Geometry"),
+        "has_model": _has_component(system, "Model"),
+        "has_setup": _has_component(system, "Setup"),
+        "has_solution": _has_component(system, "Solution"),
+    })
+
+report = {
+    "framework_version": str(GetFrameworkVersion()),
+    "project_file": project_file,
+    "systems": systems,
+    "system_count": len(systems),
+}
+''',
+    )
+
+
+def _get_workbench_session(session_id: str) -> WorkbenchSession:
+    try:
+        return _WORKBENCH_SESSIONS[session_id]
+    except KeyError as exc:
+        raise KeyError(f"Unknown Workbench session: {session_id}") from exc
+
+
+def _get_model_session(model_session_id: str) -> ModelSession:
+    try:
+        return _MODEL_SESSIONS[model_session_id]
+    except KeyError as exc:
+        raise KeyError(f"Unknown Mechanical model session: {model_session_id}") from exc
+
+
+def workbench_session_status() -> dict[str, Any]:
+    inventory = _process_inventory()
+    workbench_processes = [
+        row for row in inventory if row["name"].lower() in {"runwb2.exe", "ansysfww.exe"}
+    ]
+    sessions = [
+        {
+            "session_id": session.session_id,
+            "port": session.port,
+            "security": session.security,
+            "owned": session.owned,
+            "process_id": session.process_id,
+            "port_open": _port_is_open(session.port),
+        }
+        for session in _WORKBENCH_SESSIONS.values()
+    ]
+    model_sessions = [
+        {
+            "model_session_id": session.model_session_id,
+            "workbench_session_id": session.workbench_session_id,
+            "system_name": session.system_name,
+            "port": session.port,
+            "port_open": _port_is_open(session.port),
+        }
+        for session in _MODEL_SESSIONS.values()
+    ]
+    pyworkbench_available = importlib.util.find_spec("ansys.workbench.core") is not None
+    pymechanical_available = importlib.util.find_spec("ansys.mechanical.core") is not None
+    unmanaged = bool(workbench_processes) and not bool(sessions)
+    return _reply(
+        ok=True,
+        status="ready" if not unmanaged else "blocked_existing_workbench",
+        phase="SESSION_STATUS",
+        data={
+            "process_inventory": inventory,
+            "workbench_sessions": sessions,
+            "model_sessions": model_sessions,
+            "dependencies": {
+                "ansys_workbench_core": pyworkbench_available,
+                "ansys_mechanical_core": pymechanical_available,
+            },
+            "can_launch_without_duplicate": not bool(workbench_processes),
+            "requires_attach_port": unmanaged,
+        },
+        warnings=(
+            [
+                "A Workbench process already exists but is not managed by this MCP. "
+                "Attach to its StartServer port; launching another instance is refused."
+            ]
+            if unmanaged
+            else []
+        ),
+    )
+
+
+_BOOTSTRAP_MARKER = "WB_BOOTSTRAP_JSON:"
+
+
+def _bootstrap_bridge_report(timeout: float) -> dict[str, Any]:
+    code = r'''
+import json
+import os
+
+report = {"ok": False, "phase": "SERVER_REUSE_OR_START_ONCE"}
+try:
+    try:
+        server_port = int(GetServerPort())
+    except Exception:
+        server_port = 0
+    start_called = False
+    if server_port <= 0:
+        StartServer()
+        start_called = True
+        server_port = int(GetServerPort())
+    report.update({
+        "ok": server_port > 0,
+        "pid": int(os.getpid()),
+        "server_port": server_port,
+        "project_file": str(GetProjectFile()),
+        "systems": [str(system.Name) for system in GetAllSystems()],
+        "start_called": start_called,
+    })
+except Exception as exc:
+    report["error"] = str(exc)
+print("WB_BOOTSTRAP_JSON:" + json.dumps(report, ensure_ascii=True, sort_keys=True))
+'''
+    outer = socket_timer_execute_python(code, timeout=float(timeout))
+    if not outer.get("ok"):
+        raise RuntimeError(f"Workbench bridge request failed: {outer.get('error')}")
+    response = outer.get("response") or {}
+    if not response.get("ok"):
+        raise RuntimeError(f"Workbench bridge rejected request: {response}")
+    execution = response.get("execution") or {}
+    if not execution.get("ok"):
+        raise RuntimeError(f"Workbench bridge execution failed: {execution}")
+    stdout = str(execution.get("stdout") or "")
+    marker_lines = [
+        line[len(_BOOTSTRAP_MARKER) :]
+        for line in stdout.splitlines()
+        if line.startswith(_BOOTSTRAP_MARKER)
+    ]
+    if len(marker_lines) != 1:
+        raise RuntimeError("Workbench bootstrap did not return exactly one JSON marker")
+    report = json.loads(marker_lines[0])
+    if not isinstance(report, dict) or not report.get("ok"):
+        raise RuntimeError(f"Workbench bootstrap report failed: {report}")
+    return report
+
+
+def workbench_bootstrap_current(
+    expected_project_path: str | None = None,
+    expected_system_name: str | None = None,
+    security: str = "wnua",
+    host: str = "localhost",
+    bridge_timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Attach to the one existing Workbench without launching another instance."""
+
+    phase = "WORKBENCH_BOOTSTRAP"
+    try:
+        with _exclusive_launch_guard(timeout=float(bridge_timeout)):
+            processes = _process_inventory(strict=True)
+            runwb = [row for row in processes if row["name"].lower() == "runwb2.exe"]
+            framework = [
+                row for row in processes if row["name"].lower() == "ansysfww.exe"
+            ]
+            mechanical = [
+                row for row in processes if row["name"].lower() == "ansyswbu.exe"
+            ]
+            if len(runwb) != 1 or len(framework) != 1:
+                raise RuntimeError(
+                    "Expected exactly one RunWB2.exe and one AnsysFWW.exe; "
+                    f"observed {len(runwb)} and {len(framework)}"
+                )
+            if int(framework[0]["parent_pid"]) != int(runwb[0]["pid"]):
+                raise RuntimeError("AnsysFWW.exe is not a child of the unique RunWB2.exe")
+            if any(
+                int(row["parent_pid"]) != int(framework[0]["pid"])
+                for row in mechanical
+            ):
+                raise RuntimeError("AnsysWBU.exe exists outside the unique Workbench tree")
+
+            bridge = _bootstrap_bridge_report(timeout=float(bridge_timeout))
+            if int(bridge.get("pid") or 0) != int(framework[0]["pid"]):
+                raise RuntimeError(
+                    "Port 9885 bridge PID does not match the unique AnsysFWW.exe"
+                )
+            port = int(bridge.get("server_port") or 0)
+            if port <= 0:
+                raise RuntimeError("Workbench bootstrap returned an invalid server port")
+
+            observed_project = _normalize_path(bridge.get("project_file"))
+            expected_project = _normalize_path(expected_project_path)
+            if expected_project is not None and observed_project != expected_project:
+                raise RuntimeError(
+                    f"Expected project {expected_project}, observed {observed_project}"
+                )
+            observed_systems = [str(item) for item in (bridge.get("systems") or [])]
+            if expected_system_name is not None and observed_systems.count(
+                str(expected_system_name)
+            ) != 1:
+                raise RuntimeError(
+                    f"Expected one internal System {expected_system_name}, "
+                    f"observed {observed_systems}"
+                )
+
+        attached = workbench_attach_current(port=port, security=security, host=host)
+        if not attached.get("ok"):
+            return attached
+        session_id = str(attached["data"]["session_id"])
+        inventory = attached["data"]["inventory"]
+        inventory_project = _normalize_path(inventory.get("project_file"))
+        inventory_systems = [
+            str(item.get("name")) for item in (inventory.get("systems") or [])
+        ]
+        gate_errors: list[str] = []
+        if expected_project is not None and inventory_project != expected_project:
+            gate_errors.append(
+                f"Attached project {inventory_project} does not equal {expected_project}"
+            )
+        if expected_system_name is not None and inventory_systems.count(
+            str(expected_system_name)
+        ) != 1:
+            gate_errors.append(
+                f"Attached systems {inventory_systems} do not uniquely contain "
+                f"{expected_system_name}"
+            )
+        if gate_errors:
+            workbench_session_disconnect(session_id)
+            return _reply(
+                ok=False,
+                status="identity_gate_failed",
+                phase=phase,
+                data={"bridge": bridge, "inventory": inventory},
+                evidence={"processes": processes},
+                errors=gate_errors,
+            )
+        return _reply(
+            ok=True,
+            status=(
+                "already_bootstrapped"
+                if attached.get("status") == "already_attached"
+                else "bootstrapped"
+            ),
+            phase=phase,
+            changed=bool(bridge.get("start_called")),
+            idempotent=attached.get("status") == "already_attached",
+            data={
+                "session_id": session_id,
+                "bridge": bridge,
+                "inventory": inventory,
+            },
+            evidence={"processes": processes, "security": security, "host": host},
+        )
+    except Exception as exc:
+        return _reply(
+            ok=False,
+            status="bootstrap_failed",
+            phase=phase,
+            errors=[str(exc)],
+        )
+
+
+def workbench_attach_current(
+    port: int,
+    security: str = "mtls",
+    host: str = "localhost",
+) -> dict[str, Any]:
+    phase = "WORKBENCH_ATTACH"
+    if int(port) <= 0:
+        return _reply(ok=False, status="invalid_port", phase=phase, errors=["port must be > 0"])
+    endpoint_key = (str(host).lower(), int(port), str(security).lower())
+    with _LOCK:
+        existing_id = _WORKBENCH_ENDPOINT_INDEX.get(endpoint_key)
+        existing = _WORKBENCH_SESSIONS.get(existing_id or "")
+    if existing is not None:
+        try:
+            inventory = _workbench_inventory(existing.client)
+            return _reply(
+                ok=True,
+                status="already_attached",
+                phase=phase,
+                idempotent=True,
+                data={"session_id": existing.session_id, "inventory": inventory},
+                evidence={"port": int(port), "host": host, "security": security},
+            )
+        except Exception:
+            with _LOCK:
+                _WORKBENCH_ENDPOINT_INDEX.pop(endpoint_key, None)
+    try:
+        connect_workbench, _ = _load_pyworkbench()
+        client = connect_workbench(port=int(port), host=host, security=security)
+        inventory = _workbench_inventory(client)
+        session_id = "wb_" + uuid.uuid4().hex[:12]
+        session = WorkbenchSession(
+            session_id=session_id,
+            client=client,
+            port=int(port),
+            security=security,
+            owned=False,
+            host=host,
+        )
+        with _LOCK:
+            _WORKBENCH_SESSIONS[session_id] = session
+            _WORKBENCH_ENDPOINT_INDEX[endpoint_key] = session_id
+        return _reply(
+            ok=True,
+            status="attached",
+            phase=phase,
+            changed=False,
+            data={"session_id": session_id, "inventory": inventory},
+            evidence={"port": int(port), "host": host, "security": security},
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="attach_failed", phase=phase, errors=[str(exc)])
+
+
+def workbench_launch_managed(
+    version: str = "252",
+    show_gui: bool = True,
+    server_workdir: str | None = None,
+    use_insecure_connection: bool = False,
+) -> dict[str, Any]:
+    phase = "WORKBENCH_LAUNCH"
+    with _LOCK:
+        try:
+            with _exclusive_launch_guard():
+                # Fail closed if process discovery is unavailable.  Checking
+                # again while holding the cross-process lock closes the race
+                # between two MCP servers launching simultaneously.
+                processes = _workbench_processes(strict=True)
+                if processes:
+                    return _reply(
+                        ok=False,
+                        status="blocked_existing_workbench",
+                        phase=phase,
+                        data={"workbench_processes": processes},
+                        errors=["Refusing to launch a second Workbench instance"],
+                    )
+                connect_workbench, launcher_class = _load_pyworkbench()
+                launcher = launcher_class()
+                port, security = launcher.launch(
+                    version=version,
+                    show_gui=bool(show_gui),
+                    server_workdir=server_workdir,
+                    port_to_use=-1,
+                    use_insecure_connection=bool(use_insecure_connection),
+                )
+                if not port or int(port) <= 0:
+                    raise RuntimeError("PyWorkbench did not return a valid server port")
+                client = connect_workbench(port=int(port), host="localhost", security=security)
+                inventory = _workbench_inventory(client)
+                session_id = "wb_" + uuid.uuid4().hex[:12]
+                process_id = getattr(launcher, "_process_id", None)
+                session = WorkbenchSession(
+                    session_id=session_id,
+                    client=client,
+                    port=int(port),
+                    security=str(security),
+                    owned=True,
+                    launcher=launcher,
+                    process_id=int(process_id) if process_id and int(process_id) > 0 else None,
+                )
+                _WORKBENCH_SESSIONS[session_id] = session
+            return _reply(
+                ok=True,
+                status="launched",
+                phase=phase,
+                changed=True,
+                data={"session_id": session_id, "inventory": inventory},
+                evidence={
+                    "port": int(port),
+                    "security": str(security),
+                    "process_id": session.process_id,
+                    "version": version,
+                },
+            )
+        except Exception as exc:
+            return _reply(ok=False, status="launch_failed", phase=phase, errors=[str(exc)])
+
+
+def workbench_project_inventory(session_id: str) -> dict[str, Any]:
+    phase = "PROJECT_INVENTORY"
+    try:
+        session = _get_workbench_session(session_id)
+        inventory = _workbench_inventory(session.client)
+        return _reply(ok=True, status="inspected", phase=phase, data=inventory)
+    except Exception as exc:
+        return _reply(ok=False, status="inspection_failed", phase=phase, errors=[str(exc)])
+
+
+def workbench_project_open(session_id: str, project_path: str) -> dict[str, Any]:
+    phase = "PROJECT_OPEN"
+    path = Path(project_path).expanduser().resolve()
+    if path.suffix.lower() != ".wbpj" or not path.is_file():
+        return _reply(
+            ok=False,
+            status="invalid_project",
+            phase=phase,
+            errors=[f"Workbench project does not exist: {path}"],
+        )
+    try:
+        session = _get_workbench_session(session_id)
+        before = _workbench_inventory(session.client)
+        before_path = _normalize_path(before.get("project_file"))
+        target_path = _normalize_path(str(path))
+        if before_path == target_path:
+            return _reply(
+                ok=True,
+                status="already_open",
+                phase=phase,
+                idempotent=True,
+                data=before,
+            )
+        if int(before.get("system_count") or 0) > 0:
+            return _reply(
+                ok=False,
+                status="blocked_active_project",
+                phase=phase,
+                data={"current": before, "requested_project": str(path)},
+                errors=["A different non-empty Workbench project is already active"],
+            )
+        literal = json.dumps(str(path))
+        session.client.run_script_string(f"Open(FilePath={literal})")
+        after = _workbench_inventory(session.client)
+        if _normalize_path(after.get("project_file")) != target_path:
+            raise RuntimeError("Workbench opened a project whose identity does not match the target")
+        return _reply(
+            ok=True,
+            status="opened",
+            phase=phase,
+            changed=True,
+            data=after,
+            evidence={"project_path": str(path)},
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="open_failed", phase=phase, errors=[str(exc)])
+
+
+def workbench_project_save_as(
+    session_id: str,
+    target_path: str,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    phase = "PROJECT_SAVE_AS"
+    target = Path(target_path).expanduser().resolve()
+    if target.suffix.lower() != ".wbpj":
+        return _reply(
+            ok=False,
+            status="invalid_target",
+            phase=phase,
+            errors=["Save target must use the .wbpj extension"],
+        )
+    if target.exists() and not overwrite:
+        return _reply(
+            ok=False,
+            status="target_exists",
+            phase=phase,
+            errors=[f"Refusing to overwrite existing project: {target}"],
+        )
+    try:
+        session = _get_workbench_session(session_id)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        literal = json.dumps(str(target))
+        flag = "True" if overwrite else "False"
+        session.client.run_script_string(f"Save(FilePath={literal}, Overwrite={flag})")
+        inventory = _workbench_inventory(session.client)
+        if _normalize_path(inventory.get("project_file")) != _normalize_path(str(target)):
+            raise RuntimeError("Workbench Save As identity check failed")
+        return _reply(
+            ok=True,
+            status="saved",
+            phase=phase,
+            changed=True,
+            data=inventory,
+            evidence={"target_path": str(target), "overwrite": bool(overwrite)},
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="save_failed", phase=phase, errors=[str(exc)])
+
+
+def _select_mechanical_system(inventory: dict[str, Any], system_name: str | None) -> dict[str, Any]:
+    candidates = [
+        item
+        for item in inventory.get("systems", [])
+        if item.get("has_model") and item.get("has_solution")
+    ]
+    if system_name:
+        matches = [item for item in candidates if item.get("name") == system_name]
+        if len(matches) != 1:
+            raise RuntimeError(
+                f"Mechanical system selector matched {len(matches)} systems; expected exactly one"
+            )
+        return matches[0]
+    if len(candidates) != 1:
+        names = [str(item.get("name")) for item in candidates]
+        raise RuntimeError(
+            f"Found {len(candidates)} Mechanical systems {names}; provide the exact internal system_name"
+        )
+    return candidates[0]
+
+
+def _mechanical_state(client: Any) -> dict[str, Any]:
+    code = r'''
+import json
+report = {"ok": False}
+try:
+    from Ansys.Mechanical.DataModel.Enums import DataModelObjectCategory
+
+    try:
+        _text_type = unicode
+    except NameError:
+        _text_type = str
+
+    def _safe_text(value):
+        if value is None:
+            return None
+        try:
+            text = _text_type(value)
+        except Exception:
+            try:
+                text = _text_type(repr(value))
+            except Exception:
+                return "<unprintable>"
+        try:
+            return text.encode("unicode_escape").decode("ascii")
+        except Exception:
+            try:
+                return str(text)
+            except Exception:
+                return "<unprintable>"
+
+    project = ExtAPI.DataModel.Project
+    model = project.Model if project is not None else None
+    bodies = []
+    active_bodies = []
+    analyses = []
+    named_selections = []
+    if model is not None:
+        bodies = list(ExtAPI.DataModel.GetObjectsByType(DataModelObjectCategory.Body))
+        for body in bodies:
+            try:
+                if not bool(body.Suppressed):
+                    active_bodies.append(body)
+            except Exception:
+                active_bodies.append(body)
+        analyses = list(model.Analyses)
+        try:
+            named_selection_group = getattr(model, "NamedSelections", None)
+            if named_selection_group is not None:
+                named_selections = list(getattr(named_selection_group, "Children", []) or [])
+        except Exception:
+            named_selections = []
+        if not named_selections:
+            try:
+                named_selections = list(
+                    ExtAPI.DataModel.GetObjectsByType(DataModelObjectCategory.NamedSelection)
+                )
+            except Exception:
+                named_selections = []
+    application_version = None
+    try:
+        application_version = _safe_text(ExtAPI.Application.ApplicationVersion)
+    except Exception:
+        pass
+    report = {
+        "ok": (
+            project is not None
+            and model is not None
+            and len(active_bodies) > 0
+            and len(analyses) > 0
+        ),
+        "application_version": application_version,
+        "project_directory": _safe_text(getattr(project, "ProjectDirectory", "")) if project is not None else None,
+        "model_present": model is not None,
+        "body_count": len(bodies),
+        "body_names": [_safe_text(getattr(body, "Name", "")) for body in bodies],
+        "active_body_count": len(active_bodies),
+        "active_body_names": [_safe_text(getattr(body, "Name", "")) for body in active_bodies],
+        "analysis_count": len(analyses),
+        "analyses": [{
+            "name": _safe_text(getattr(analysis, "Name", "")),
+            "analysis_type": _safe_text(getattr(analysis, "AnalysisType", "")),
+            "working_directory": _safe_text(getattr(analysis, "WorkingDir", "")),
+        } for analysis in analyses],
+        "named_selection_count": len(named_selections),
+        "named_selection_names": [
+            _safe_text(getattr(named_selection, "Name", ""))
+            for named_selection in named_selections
+        ],
+    }
+except Exception as exc:
+    try:
+        error_text = _safe_text(exc)
+    except Exception:
+        error_text = "Mechanical state inspection failed"
+    report = {"ok": False, "error": error_text}
+json.dumps(report, ensure_ascii=True)
+'''
+    raw = client.run_python_script(code)
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        raise RuntimeError(f"Unexpected Mechanical result type: {type(raw).__name__}")
+    decoded = json.loads(raw)
+    if not isinstance(decoded, dict):
+        raise RuntimeError("Mechanical state result must be an object")
+    for key in ("body_names", "active_body_names", "named_selection_names"):
+        decoded[key] = [_decode_mechanical_text(item) for item in decoded.get(key, [])]
+    for key in ("application_version", "project_directory", "error"):
+        if key in decoded:
+            decoded[key] = _decode_mechanical_text(decoded.get(key))
+    for analysis in decoded.get("analyses", []):
+        if isinstance(analysis, dict):
+            for key in ("name", "analysis_type", "working_directory"):
+                analysis[key] = _decode_mechanical_text(analysis.get(key))
+    return decoded
+
+
+def _decode_mechanical_text(value: Any) -> str:
+    """Decode ``unicode_escape`` text returned by Mechanical's IronPython layer."""
+
+    if value is None:
+        return ""
+    text = str(value)
+    if not any(marker in text for marker in ("\\\\", "\\u", "\\U", "\\x")):
+        return text
+    try:
+        return bytes(text, "ascii").decode("unicode_escape")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return text
+
+
+def _working_directory_matches_system(value: Any, system_name: str) -> bool:
+    if not value:
+        return False
+    parts = [os.path.normcase(part) for part in Path(str(value)).parts]
+    expected = os.path.normcase(system_name)
+    mech = os.path.normcase("MECH")
+    return any(
+        parts[index] == expected and parts[index + 1] == mech
+        for index in range(max(0, len(parts) - 1))
+    )
+
+
+def _exact_name_gate(observed: list[Any], expected: list[str] | None, label: str) -> list[str]:
+    if expected is None:
+        return []
+    observed_names = sorted(str(item) for item in observed)
+    expected_names = sorted(str(item) for item in expected)
+    if observed_names == expected_names:
+        return []
+    return [f"Expected exact {label} {expected_names}, observed {observed_names}"]
+
+
+def workbench_model_open(
+    session_id: str,
+    system_name: str | None = None,
+    transport_mode: str | None = None,
+    connect_timeout: float = 120.0,
+    mechanical_port: int | None = None,
+) -> dict[str, Any]:
+    phase = "MODEL_OPEN"
+    try:
+        workbench_session = _get_workbench_session(session_id)
+        inventory = _workbench_inventory(workbench_session.client)
+        project_file = _normalize_path(inventory.get("project_file"))
+        if not project_file:
+            raise RuntimeError("Workbench has no saved project identity; refusing to open Model")
+        system = _select_mechanical_system(inventory, system_name)
+        exact_name = str(system["name"])
+        index_key = (session_id, exact_name)
+        with _LOCK:
+            existing_id = _MODEL_INDEX.get(index_key)
+            if existing_id and existing_id in _MODEL_SESSIONS:
+                existing = _MODEL_SESSIONS[existing_id]
+                state = _mechanical_state(existing.client)
+                return _reply(
+                    ok=bool(state.get("ok")),
+                    status="already_open" if state.get("ok") else "stale_model_session",
+                    phase=phase,
+                    idempotent=True,
+                    data={"model_session_id": existing_id, "system": system, "state": state},
+                    evidence={"mechanical_port": existing.port},
+                )
+            if index_key in _MODEL_OPENING:
+                return _reply(
+                    ok=False,
+                    status="model_open_in_progress",
+                    phase=phase,
+                    idempotent=True,
+                    data={"system": system},
+                    errors=["Another request is already opening this exact Workbench Model"],
+                )
+            _MODEL_OPENING.add(index_key)
+
+        try:
+            # PyWorkbench 0.14 has a known risky path when a non-zero port is
+            # passed.  Let Workbench allocate a dynamic port and use the
+            # returned value as the authoritative endpoint.
+            endpoint_key = (project_file, exact_name)
+            with _LOCK:
+                cached_port = _MODEL_ENDPOINTS.get(endpoint_key)
+                if mechanical_port is not None:
+                    requested_port = int(mechanical_port)
+                    if requested_port <= 0:
+                        raise RuntimeError("mechanical_port must be > 0")
+                    if cached_port is not None and int(cached_port) != requested_port:
+                        raise RuntimeError(
+                            f"Mechanical endpoint conflict: cached {cached_port}, "
+                            f"requested {requested_port}"
+                        )
+                    _MODEL_ENDPOINTS[endpoint_key] = requested_port
+                    cached_port = requested_port
+            if cached_port is None:
+                port = int(
+                    workbench_session.client.start_mechanical_server(
+                        system_name=exact_name, port=0
+                    )
+                )
+                if port <= 0:
+                    raise RuntimeError(
+                        "Workbench did not return a valid Mechanical server port"
+                    )
+                with _LOCK:
+                    _MODEL_ENDPOINTS[endpoint_key] = port
+            else:
+                port = int(cached_port)
+            if port <= 0:
+                raise RuntimeError("Workbench did not return a valid Mechanical server port")
+            connect_to_mechanical = _load_pymechanical()
+            mechanical = connect_to_mechanical(
+                ip="127.0.0.1",
+                port=port,
+                connect_timeout=float(connect_timeout),
+                clear_on_connect=False,
+                cleanup_on_exit=False,
+                keep_connection_alive=True,
+                transport_mode=transport_mode,
+            )
+            state = _mechanical_state(mechanical)
+            if not state.get("ok"):
+                raise RuntimeError(f"Mechanical Model gate failed: {state}")
+            model_session_id = "model_" + uuid.uuid4().hex[:12]
+            model_session = ModelSession(
+                model_session_id=model_session_id,
+                workbench_session_id=session_id,
+                system_name=exact_name,
+                client=mechanical,
+                port=port,
+                transport_mode=transport_mode,
+                project_file=project_file,
+            )
+            with _LOCK:
+                _MODEL_SESSIONS[model_session_id] = model_session
+                _MODEL_INDEX[index_key] = model_session_id
+        finally:
+            with _LOCK:
+                _MODEL_OPENING.discard(index_key)
+        return _reply(
+            ok=True,
+            status="model_ready",
+            phase=phase,
+            changed=True,
+            data={"model_session_id": model_session_id, "system": system, "state": state},
+            evidence={"mechanical_port": port, "transport_mode": transport_mode},
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="model_open_failed", phase=phase, errors=[str(exc)])
+
+
+def workbench_model_state(
+    model_session_id: str,
+    expected_body_count: int | None = None,
+    expected_analysis_count: int | None = None,
+    expected_project_path: str | None = None,
+    expected_system_name: str | None = None,
+    expected_body_names: list[str] | None = None,
+    expected_analysis_names: list[str] | None = None,
+    expected_analysis_types: list[str] | None = None,
+) -> dict[str, Any]:
+    phase = "MODEL_STATE"
+    try:
+        session = _get_model_session(model_session_id)
+        state = _mechanical_state(session.client)
+        gate_errors: list[str] = []
+        parent = _get_workbench_session(session.workbench_session_id)
+        workbench_inventory = _workbench_inventory(parent.client)
+        current_project = _normalize_path(workbench_inventory.get("project_file"))
+        recorded_project = _normalize_path(session.project_file)
+        requested_project = _normalize_path(expected_project_path)
+        if not current_project or current_project != recorded_project:
+            gate_errors.append(
+                f"Workbench project identity changed: expected {recorded_project}, observed {current_project}"
+            )
+        if requested_project is not None and current_project != requested_project:
+            gate_errors.append(
+                f"Expected project {requested_project}, observed {current_project}"
+            )
+
+        exact_systems = [
+            item
+            for item in workbench_inventory.get("systems", [])
+            if str(item.get("name")) == session.system_name and item.get("has_model")
+        ]
+        if len(exact_systems) != 1:
+            gate_errors.append(
+                f"Expected exact Workbench system {session.system_name}, matched {len(exact_systems)}"
+            )
+        if expected_system_name is not None and expected_system_name != session.system_name:
+            gate_errors.append(
+                f"Expected system {expected_system_name}, model session is {session.system_name}"
+            )
+
+        working_directories = [
+            analysis.get("working_directory") for analysis in state.get("analyses", [])
+        ]
+        if not any(
+            _working_directory_matches_system(path, session.system_name)
+            for path in working_directories
+        ):
+            gate_errors.append(
+                f"No Mechanical analysis WorkingDir maps to exact Workbench system {session.system_name}"
+            )
+
+        active_body_count = int(state.get("active_body_count", state.get("body_count", -1)))
+        active_body_names = state.get("active_body_names", state.get("body_names", []))
+        if expected_body_count is not None and active_body_count != int(
+            expected_body_count
+        ):
+            gate_errors.append(
+                f"Expected {expected_body_count} active bodies, observed {active_body_count}"
+            )
+        if expected_analysis_count is not None and int(state.get("analysis_count", -1)) != int(
+            expected_analysis_count
+        ):
+            gate_errors.append(
+                f"Expected {expected_analysis_count} analyses, observed {state.get('analysis_count')}"
+            )
+        gate_errors.extend(_exact_name_gate(active_body_names, expected_body_names, "active bodies"))
+        gate_errors.extend(
+            _exact_name_gate(
+                [item.get("name") for item in state.get("analyses", [])],
+                expected_analysis_names,
+                "analyses",
+            )
+        )
+        gate_errors.extend(
+            _exact_name_gate(
+                [item.get("analysis_type") for item in state.get("analyses", [])],
+                expected_analysis_types,
+                "analysis types",
+            )
+        )
+        ok = bool(state.get("ok")) and not gate_errors
+        return _reply(
+            ok=ok,
+            status="model_ready" if ok else "model_gate_failed",
+            phase=phase,
+            data={
+                "model_session_id": model_session_id,
+                "state": state,
+                "workbench_inventory": workbench_inventory,
+            },
+            evidence={
+                "mechanical_port": session.port,
+                "system_name": session.system_name,
+                "project_file": current_project,
+            },
+            errors=gate_errors,
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="state_failed", phase=phase, errors=[str(exc)])
+
+
+def workbench_model_execute_python(model_session_id: str, code: str) -> dict[str, Any]:
+    phase = "MODEL_EXECUTE_PYTHON"
+    if not code or not code.strip():
+        return _reply(ok=False, status="empty_code", phase=phase, errors=["code is empty"])
+    try:
+        session = _get_model_session(model_session_id)
+        gate = workbench_model_state(
+            model_session_id=model_session_id,
+            expected_project_path=session.project_file,
+            expected_system_name=session.system_name,
+        )
+        if not gate.get("ok"):
+            return _reply(
+                ok=False,
+                status="identity_gate_failed",
+                phase=phase,
+                data={"model_session_id": model_session_id, "gate": gate},
+                evidence={"mechanical_port": session.port},
+                errors=list(gate.get("errors") or ["Model identity gate failed"]),
+            )
+        result = session.client.run_python_script(code)
+        return _reply(
+            ok=True,
+            status="executed",
+            phase=phase,
+            changed=True,
+            data={"model_session_id": model_session_id, "result": result},
+            evidence={"mechanical_port": session.port, "system_name": session.system_name},
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="execution_failed", phase=phase, errors=[str(exc)])
+
+
+def _close_client_channel_only(client: Any, *, workbench: bool) -> str:
+    """Close only the client transport, never an ANSYS application process."""
+
+    attribute_names = ("channel",) if workbench else ("_channel", "channel")
+    for attribute_name in attribute_names:
+        channel = getattr(client, attribute_name, None)
+        close = getattr(channel, "close", None)
+        if callable(close):
+            close()
+            try:
+                setattr(client, attribute_name, None)
+            except Exception:
+                pass
+            if workbench:
+                for name in ("stub", "_stub"):
+                    if hasattr(client, name):
+                        try:
+                            setattr(client, name, None)
+                        except Exception:
+                            pass
+            return f"closed_{attribute_name}"
+    return "registry_only_no_channel_api"
+
+
+def workbench_session_disconnect(session_id: str) -> dict[str, Any]:
+    """Disconnect the PyWorkbench client without resetting or closing Workbench.
+
+    Mechanical model clients are intentionally not ``exit()``-ed because
+    PyMechanical's exit operation can terminate the Workbench-managed
+    Mechanical process.  The caller must explicitly own any later termination.
+    """
+
+    phase = "SESSION_DISCONNECT"
+    model_detach_modes: dict[str, str] = {}
+    try:
+        with _LOCK:
+            session = _get_workbench_session(session_id)
+            child_ids = [
+                model_id
+                for model_id, model_session in _MODEL_SESSIONS.items()
+                if model_session.workbench_session_id == session_id
+            ]
+            for model_id in child_ids:
+                model_session = _MODEL_SESSIONS.pop(model_id)
+                _MODEL_INDEX.pop((session_id, model_session.system_name), None)
+                model_detach_modes[model_id] = _close_client_channel_only(
+                    model_session.client, workbench=False
+                )
+            _WORKBENCH_SESSIONS.pop(session_id, None)
+            _WORKBENCH_ENDPOINT_INDEX.pop(
+                (str(session.host).lower(), int(session.port), str(session.security).lower()),
+                None,
+            )
+        workbench_detach_mode = _close_client_channel_only(session.client, workbench=True)
+        return _reply(
+            ok=True,
+            status="disconnected",
+            phase=phase,
+            changed=True,
+            data={
+                "session_id": session_id,
+                "detached_model_sessions": child_ids,
+                "workbench_detach_mode": workbench_detach_mode,
+                "model_detach_modes": model_detach_modes,
+            },
+            warnings=[
+                "Only MCP client channels were detached; Workbench and Mechanical processes were left running"
+            ],
+        )
+    except Exception as exc:
+        return _reply(ok=False, status="disconnect_failed", phase=phase, errors=[str(exc)])

--- a/MCP/Ansys/Workbench MCP/workbench_plugin/__init__.py
+++ b/MCP/Ansys/Workbench MCP/workbench_plugin/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for the distributable Workbench MCP ACT bridge resources."""

--- a/MCP/Ansys/Workbench MCP/workbench_plugin/mechanical_queue_processor.py
+++ b/MCP/Ansys/Workbench MCP/workbench_plugin/mechanical_queue_processor.py
@@ -197,12 +197,27 @@ def _execute_python(code):
     sys.stdout = stdout
     sys.stderr = stderr
     try:
+        data_model = ExtAPI.DataModel
+        project = data_model.Project
+        model = None
+        if project is not None:
+            model = project.Model
+        tree = None
+        try:
+            tree = data_model.Tree
+        except Exception:
+            pass
         env = {
             "ExtAPI": ExtAPI,
-            "Model": Model,
-            "DataModel": DataModel,
-            "Tree": Tree,
+            "Model": model,
+            "DataModel": data_model,
+            "Tree": tree,
         }
+        try:
+            from Ansys.Core.Units import Quantity
+            env["Quantity"] = Quantity
+        except Exception:
+            pass
         exec(code, env, env)
         return {
             "ok": True,

--- a/Skill/Ansys/ansys-structural-workbench/SKILL.md
+++ b/Skill/Ansys/ansys-structural-workbench/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: ansys-structural-workbench
-description: Orchestrate evidence-backed ANSYS Workbench and Mechanical structural analyses through a configured MCP, including capability discovery, existing-project or CAD intake, materials, named selections, connections, loads, high-quality mesh planning and repair, solving, convergence diagnosis, deterministic validation, and report export. Use for linear static, nonlinear static, contact, modal, eigenvalue buckling, or related structural-analysis work when Codex must operate or inspect a live Workbench session instead of only explaining theory.
+description: "Operate or inspect live ANSYS Workbench Mechanical structural simulations through the configured MCP, including model setup, materials, connections, loads, mesh, solve, convergence, validation, and reporting. Use whenever a user asks Codex to create, configure, inspect, mesh, solve, troubleshoot, or validate a live Workbench structural analysis. Before model decisions or mutation, load ansys-workbench-practical-reference once as the book-distilled router and then the matching narrow reference Skill. Load static-modeling for every Static Structural task, plus nonlinear-contact for contact, friction, plasticity, large deformation, buckling, or nonlinear convergence. Do not use for theory-only questions or Fluent/CFX operation."
 ---
 
 # ANSYS Structural Workbench
 
 Operate Workbench as an engineering workflow with explicit quality gates. Treat the MCP as the execution adapter and this Skill as the analysis, meshing, validation, and reporting policy.
+
+## Mandatory book-guidance route
+
+Before inspecting settings for engineering acceptance, mutating the model, meshing, or solving, load `ansys-workbench-practical-reference` once and use it to select the physics-specific book-derived guidance. This is a required intake gate, not an optional source lookup.
+
+- Every Static Structural task must load `ansys-workbench-static-modeling-reference`.
+- A static task with contact or friction must load both `ansys-workbench-static-modeling-reference` and `ansys-workbench-nonlinear-contact-reference`.
+- Also load `ansys-workbench-nonlinear-contact-reference` for plasticity, large deflection, buckling, stabilization, changing contact state, or nonlinear convergence.
+- Modal, transient, explicit, thermal, and optimization tasks load only their matching narrow reference Skill; do not load unrelated book domains.
+
+The book-derived Skills govern modeling assumptions and physical checks. This Skill governs live MCP actions, evidence, and safe execution. Record which guidance Skills were loaded in the task intake or final report. Do not repeatedly re-route after the applicable set has been loaded.
 
 ## Start safely
 


### PR DESCRIPTION
## Summary
- add 11 high-level Workbench/model session tools
- retain and package 16 Mechanical structural workflow tools from current main
- expose 45 MCP tools total
- add guarded Fusion STEP/beam intake templates and validation tests
- package console entry point, ACT resources, wheel and sdist metadata
- persist mandatory book-guidance routing in the ANSYS structural Skill
- fix Workbench IronPython Unicode handling for Chinese/non-ASCII project paths

## Validation
- 34 pytest tests passed
- compileall passed
- wheel and sdist built; twine check passed
- isolated 0.2.1 wheel installation and pip check passed
- installed console completed real MCP stdio initialize/list_tools with 45 tools
- live, non-mutating Workbench integration passed: exact Chinese project identity, SYS inventory, attach and safe disconnect

## Release artifacts
- 0.2.1 wheel SHA256 F9683CB45CEFD442446ED2E7D3090C109729702310926D4BCEC91FA98F014979
- 0.2.1 sdist SHA256 DEE236204B0FB3197DC4AFB48F6B68B1444AEF194D29584D8F9557DF6427F286

Runtime queue directories and local dist output are intentionally excluded from the source commit.